### PR TITLE
(GH 63) Added Support For Default Proxy.

### DIFF
--- a/Source/GitReleaseManager.Cli/Options/BaseGitHubSubOptions.cs
+++ b/Source/GitReleaseManager.Cli/Options/BaseGitHubSubOptions.cs
@@ -5,8 +5,10 @@
 
 namespace GitReleaseManager.Cli.Options
 {
+    using System.Net;
     using CommandLine;
     using Octokit;
+    using Octokit.Internal;
 
     public abstract class BaseGitHubSubOptions : BaseSubOptions
     {
@@ -25,7 +27,10 @@ namespace GitReleaseManager.Cli.Options
         public GitHubClient CreateGitHubClient()
         {
             var credentials = new Credentials(this.UserName, this.Password);
-            var github = new GitHubClient(new ProductHeaderValue("GitReleaseManager")) { Credentials = credentials };
+            var proxy = WebRequest.DefaultWebProxy;
+            proxy.Credentials = CredentialCache.DefaultNetworkCredentials;
+            var connection = new Connection(new ProductHeaderValue("GitReleaseManager"), new HttpClientAdapter(proxy));
+            var github = new GitHubClient(connection) { Credentials = credentials };
             return github;
         }
     }


### PR DESCRIPTION
When constructing the GitHubClient a Connection is now provided that uses
the default web proxy, loaded with the default network credentials from
the credentials cache.

This should now result in GitReleaseManager working in environments with a
configured proxy in the internet options.

Fixes #63