### PR TITLE
(GH 65) Support Label Precedence

### DIFF
--- a/Source/GitReleaseManager/Configuration/Config.cs
+++ b/Source/GitReleaseManager/Configuration/Config.cs
@@ -42,6 +42,8 @@ namespace GitReleaseManager.Core.Configuration
                                    {
                                        "Internal Refactoring"
                                    };
+
+            this.IssueLabelsPrecedence = new List<string>();
         }
 
         [YamlMember(Alias = "create")]
@@ -55,5 +57,8 @@ namespace GitReleaseManager.Core.Configuration
 
         [YamlMember(Alias = "issue-labels-exclude")]
         public IList<string> IssueLabelsExclude { get; private set; }
+
+        [YamlMember(Alias = "issue-labels-precedence")]
+        public IList<string> IssueLabelsPrecedence { get; private set; } 
     }
 }


### PR DESCRIPTION
Added the ability to define label precedence behaviour in the
`GitReleaseManager.yaml` file.

This is achieved using a new config section "issue-labels-precedence" in
which the top-to-bottom ordering of labels from both the inclusion and
exclusion list is used to determine the action to take for any given
issue.

Files without this configuration section work as if all labels have the
same precedence, and therefore action to be taken depends entirely upon
the ordering of labels against the issue itself.

The release notes builder functions differently in that it now filters
issues for inclusion based on the label(s) applied to it, and their
respective precedence.

The following behaviour is now exhibited:

1. If issue has no labels - exception
2. If issue has more than one label from the inclusion list - exception
3. Whether an issue is included in release notes depends on the first
label from the label(s) against an issue, ordered by their precedence.

E.g. an issue with labels (Bug, wontfix) where Bug is inclusionary,
wontfix is exclusionary and wontfix has higher precedence, would result in
the issue being excluded.

Currently this will error if an issue has multiple inclusionary labels,
simply because it's not possible to determine which heading to place it
under (single / multiple?) - this could also be modified to take cue from
precedence, but not deemed hugely important above getting the tool being
able to actually handle exclusionary labels.

Fixes #65