### PR TITLE
(GH-93) fix internal links in docs

### DIFF
--- a/docs/configuration/create-configuration.md
+++ b/docs/configuration/create-configuration.md
@@ -22,7 +22,7 @@ This would result in the following [release notes](https://github.com/chocolatey
 <div class="admonition note">
     <p class="first admonition-title">Note</p>
     <p class="last">
-        The generated URL for the link to Chocolatey.org includes the milestone number.  The complete URL is https://chocolatey.org/packages/chocolateyGUI/0.13.1.  This was achieved by using a regular expression replacement of the [footer-content](doc:default-configuration), using the [milestone-replace-text](doc:default-configuration) property as the text to replace with the actual milestone.
+        The generated URL for the link to Chocolatey.org includes the milestone number.  The complete URL is https://chocolatey.org/packages/chocolateyGUI/0.13.1.  This was achieved by using a regular expression replacement of the [footer-content](default-configuration.md), using the [milestone-replace-text](default-configuration.md) property as the text to replace with the actual milestone.
 
 This approach can be used for any project, this example simply shows what is done in the ChocolateyGUI project.
     </p>

--- a/docs/configuration/default-configuration.md
+++ b/docs/configuration/default-configuration.md
@@ -48,7 +48,7 @@ When creating a Release, there are a number of options which can be set to contr
   * **milestone-replace-text**
     * A string value which contains the string which should be replaced in the footer-content with the actual milestone release number. Default is an empty string.
 
-See the [example create configuration section](doc:create-configuration) to see an example of how a footer can be configured.
+See the [example create configuration section](create-configuration.md) to see an example of how a footer can be configured.
 
 ## Export Options
 
@@ -63,10 +63,10 @@ See the [example create configuration section](doc:create-configuration) to see 
   * **multiline-regex**
     * A boolean value which indicates that the regular expression should span multiple lines.  Default is false.
 
-See the [example export configuration section](doc:export-configuration) to see an example of how the export can be configured.
+See the [example export configuration section](export-configuration.md) to see an example of how the export can be configured.
 
 ## Issues to include
-See the [Issues to include](doc:issues-to-include) section.
+See the [Issues to include](include-issues.md) section.
 
 ## Issues to exclude
-See the [Issues to exclude](doc:issues-to-exclude) section.
+See the [Issues to exclude](exclude-issues.md) section.

--- a/docs/why-grm.md
+++ b/docs/why-grm.md
@@ -1,6 +1,6 @@
 # Why would I want to use GitReleaseManager?
 
-There are a number of reasons that you would want to incorporate GitReleaseManager into your workflow.  
+There are a number of reasons that you would want to incorporate GitReleaseManager into your workflow.
 
 <div class="admonition note">
     <p class="first admonition-title">Note</p>
@@ -13,11 +13,11 @@ Here are a few examples:
 
 ## Create Milestone Release Notes
 
-Assuming that you are already using the concept of milestones in GitHub, once a milestone is completed, and you have a number of closed issues, you can use the [create command](doc:create) to generate a draft set of release notes, which includes all the closed issues (assuming that they match the [set of labels](doc:issues-to-include) which are configured to be included.
+Assuming that you are already using the concept of milestones in GitHub, once a milestone is completed, and you have a number of closed issues, you can use the [create command](commands/create.md) to generate a draft set of release notes, which includes all the closed issues (assuming that they match the [set of labels](configuration/include-issues.md) which are configured to be included.
 
 ## Publish Release
 
-Even if you don't want to use GitReleaseManager to create the release notes on GitHub, you may still want the ability to Publish a Release (which has the result of creating a tag in your repository).  This can be done using the [publish command](doc:publish).
+Even if you don't want to use GitReleaseManager to create the release notes on GitHub, you may still want the ability to Publish a Release (which has the result of creating a tag in your repository).  This can be done using the [publish command](commands/publish.md).
 
 <div class="admonition note">
     <p class="first admonition-title">Note</p>
@@ -28,12 +28,12 @@ Even if you don't want to use GitReleaseManager to create the release notes on G
 
 ## Add Asset to Release
 
-As part of your Release process, you may want to include assets into the GitHub Release.  This could be the final MSI package for your application, or a nuget package.  GitReleaseManager allows you to do this in two ways.  The first is using the [create command](doc:create), which includes the ability to add an asset at the time of Release creation.  However, at the time of Release creation, you might not have all the assets that you want to add.  As a result, there is a separate [add asset](doc:add-asset) command that you can use to add an asset to an existing Release.
+As part of your Release process, you may want to include assets into the GitHub Release.  This could be the final MSI package for your application, or a nuget package.  GitReleaseManager allows you to do this in two ways.  The first is using the [create command](commands/create.md), which includes the ability to add an asset at the time of Release creation.  However, at the time of Release creation, you might not have all the assets that you want to add.  As a result, there is a separate [add asset](commands/add-assets.md) command that you can use to add an asset to an existing Release.
 
 ## Close Milestone
 
-When working directly in GitHub, publishing a Release doesn't close the associated milestone.  When using the GitReleaseManager's [publish command](doc:publish) the associated milestone is also closed.  However, you can also use the [close command](doc:close] directly if you are not using the publish workflow as part of your process.
+When working directly in GitHub, publishing a Release doesn't close the associated milestone.  When using the GitReleaseManager's [publish command](commands/publish.md) the associated milestone is also closed.  However, you can also use the [close command](commands/doc:close] directly if you are not using the publish workflow as part of your process.
 
 ## Export Release Notes
 
-When working on a project, you might want to include all the Release Notes within the application itself, let's say in the About dialog.  GitReleaseManager's [export command](doc:export) makes it really simple to export the entire history of your application/product, by creating a markdown file with all the information contained in the releases section of GitHub.
+When working on a project, you might want to include all the Release Notes within the application itself, let's say in the About dialog.  GitReleaseManager's [export command](commands/export.md) makes it really simple to export the entire history of your application/product, by creating a markdown file with all the information contained in the releases section of GitHub.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: GitReleaseManager
 theme: readthedocs
 repo_url: https://github.com/GitTools/GitReleaseManager
+strict: true
 
 pages:
 - What is GitReleaseManager: index.md


### PR DESCRIPTION
Fixes #93.

I had a look around to see if the `doc:pagename` syntax was supposed to be a thing because it's the first time I use MkDocs but I couldn't find anything so I suppose they were more of a reminder of what page each link had to go to.

I also enabled [strict mode](http://www.mkdocs.org/user-guide/configuration/#strict) in the config. This throws an error when a bad link is found instead of a warning. Let me know if you'd rather have a warning.