### PR TITLE
Added fix for GitHub's new TLS 1.2 requirement.

### DIFF
--- a/Source/GitReleaseManager.Cli/Program.cs
+++ b/Source/GitReleaseManager.Cli/Program.cs
@@ -11,6 +11,7 @@ namespace GitReleaseManager.Cli
     using System.Globalization;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Text;
     using System.Threading.Tasks;
     using CommandLine;
@@ -28,6 +29,10 @@ namespace GitReleaseManager.Cli
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Not required")]
         private static int Main(string[] args)
         {
+            // Just add the TLS 1.2 protocol to the Service Point manager until
+            // we've upgraded to latest Octokit.
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
             var fileSystem = new FileSystem();
 
             return Parser.Default.ParseArguments<CreateSubOptions, AddAssetSubOptions, CloseSubOptions, PublishSubOptions, ExportSubOptions, InitSubOptions, ShowConfigSubOptions>(args)


### PR DESCRIPTION
This fix justs add the TLS 1.2 protocol to the ServicePointManager as a workaround to GitHub's new TLS 1.2 requirement. The correct approach should be to upgrade to latest Octokit, but upgrading from 0.17 to 0.29 contained too many breaking changes.

This should make it possible to do a service release.