### PR TITLE
(GH-41) Implementing ability to dogfood GitReleaseManager during build

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -22,4 +22,15 @@ ToolSettings.SetToolSettings(context: Context,
                             testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* -[Octokit]* -[YamlDotNet]* -[AlphaFS]* -[ApprovalTests]* -[ApprovalUtilities]*",
                             testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
                             testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs");
+
+BuildParameters.Tasks.DotNetCoreBuildTask.Does((context) =>
+{
+    var buildDir = BuildParameters.Paths.Directories.PublishedApplications;
+
+    var grmExecutable = context.GetFiles(buildDir + "/**/*.exe").First();
+
+    context.Information("Registering Built GRM executable...");
+    context.Tools.RegisterFile(grmExecutable);
+});
+
 Build.RunDotNetCore();

--- a/recipe.cake
+++ b/recipe.cake
@@ -36,4 +36,10 @@ BuildParameters.Tasks.DotNetCoreBuildTask.Does((context) =>
 BuildParameters.Tasks.CreateReleaseNotesTask
     .IsDependentOn(BuildParameters.Tasks.DotNetCoreBuildTask); // We need to be sure that the executable exist, and have been registered before using it
 
+((CakeTask)BuildParameters.Tasks.ExportReleaseNotesTask.Task).ErrorHandler = null;
+((CakeTask)BuildParameters.Tasks.PublishGitHubReleaseTask.Task).ErrorHandler = null;
+BuildParameters.Tasks.PublishChocolateyPackagesTask.IsDependentOn(BuildParameters.Tasks.PublishGitHubReleaseTask);
+BuildParameters.Tasks.PublishNuGetPackagesTask.IsDependentOn(BuildParameters.Tasks.PublishGitHubReleaseTask);
+BuildParameters.Tasks.PublishMyGetPackagesTask.IsDependentOn(BuildParameters.Tasks.PublishGitHubReleaseTask);
+
 Build.RunDotNetCore();

--- a/recipe.cake
+++ b/recipe.cake
@@ -33,4 +33,7 @@ BuildParameters.Tasks.DotNetCoreBuildTask.Does((context) =>
     context.Tools.RegisterFile(grmExecutable);
 });
 
+BuildParameters.Tasks.CreateReleaseNotesTask
+    .IsDependentOn(BuildParameters.Tasks.DotNetCoreBuildTask); // We need to be sure that the executable exist, and have been registered before using it
+
 Build.RunDotNetCore();


### PR DESCRIPTION
This PR pretty much duplicates all of the tasks in Cake.Recipe that makes use of GitReleaseManager (with the exception of creating labels).

I noticed the issue, and figured, why not.

fixes #41 