### PR TITLE
(GH-130) Build with Cake.Recipe 1.0.0 / Cake 0.32.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,7 +36,7 @@ notifications:
 #---------------------------------#
 cache:
 - Source\packages -> Source\**\packages.config
-- Tools -> build.ps1
+- Tools -> recipe.cake
 
 #---------------------------------#
 #  Skip builds for doc changes    #

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:https://ci.appveyor.com/nuget/cake-recipe?package=Cake.Recipe&prerelease
+#load nuget:?package=Cake.Recipe&version=1.0.0
 
 Environment.SetVariableNames(githubUserNameVariable: "GITTOOLS_GITHUB_USERNAME",
                             githubPasswordVariable: "GITTOOLS_GITHUB_PASSWORD");

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.31.0" />
+    <package id="Cake" version="0.32.1" />
 </packages>


### PR DESCRIPTION
Pin Cake.Recipe to 1.0.0 and build with required Cake version 0.3.2.1.

Also invalidates AppVeyor cache if build script has changed (instead of bootstrapper).

Fixes #130 