### PR TITLE
(GH-151) Add ability to create sample GitReleaseManager.yaml using yaml parser

### DIFF
--- a/Source/GitReleaseManager.Tests/ConfigurationTests.cs
+++ b/Source/GitReleaseManager.Tests/ConfigurationTests.cs
@@ -6,6 +6,7 @@
 
 namespace GitReleaseManager.Tests
 {
+    using System;
     using System.IO;
     using System.Text;
     using GitReleaseManager.Core.Configuration;
@@ -49,6 +50,76 @@ namespace GitReleaseManager.Tests
 
             // Then
             Assert.That(builder.ToString(), Contains.Substring("include-footer: false"));
+        }
+
+        [Test]
+        public void Should_WriteSample_Keys_Without_Values()
+        {
+            // Given
+            var builder = new StringBuilder();
+
+            // When
+            using (var writer = new StringWriter(builder))
+            {
+                ConfigSerializer.WriteSample(writer);
+            }
+            var text = builder.ToString();
+
+            // Then
+            Assert.That(text, Contains.Substring("#create:" + Environment.NewLine));
+            Assert.That(text, Contains.Substring("#export:" + Environment.NewLine));
+        }
+
+        [Test]
+        public void Should_WriteSample_Boolean_Values()
+        {
+            // Given
+            var builder = new StringBuilder();
+
+            // When
+            using (var writer = new StringWriter(builder))
+            {
+                ConfigSerializer.WriteSample(writer);
+            }
+            var text = builder.ToString();
+
+            // Then
+            Assert.That(text, Contains.Substring("#  include-footer: true"));
+        }
+
+        [Test]
+        public void Should_WriteSample_String_Values()
+        {
+            // Given
+            var builder = new StringBuilder();
+
+            // When
+            using (var writer = new StringWriter(builder))
+            {
+                ConfigSerializer.WriteSample(writer);
+            }
+            var text = builder.ToString();
+
+            // Then
+            Assert.That(text, Contains.Substring("#  footer-heading: Where to get it"));
+        }
+
+        [Test]
+        public void Should_WriteSample_Multiline_String_Values()
+        {
+            // Given
+            var builder = new StringBuilder();
+
+            // When
+            using (var writer = new StringWriter(builder))
+            {
+                ConfigSerializer.WriteSample(writer);
+            }
+            var text = builder.ToString();
+
+            // Then
+            var expectedText = string.Format("#  footer-content: >-{0}#    You can download this release from{0}#{0}#    [chocolatey](https://chocolatey.org/packages/chocolateyGUI/{{milestone}})", Environment.NewLine);
+            Assert.That(text, Contains.Substring(expectedText));
         }
     }
 }

--- a/Source/GitReleaseManager.Tests/Resources.resx
+++ b/Source/GitReleaseManager.Tests/Resources.resx
@@ -118,28 +118,33 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Default_Configuration_Yaml" xml:space="preserve">
-    <value>create:
+    <value># Configuration values used when creating new releases
+create:
   include-footer: false
   footer-heading:
   footer-content:
   footer-includes-milestone: false
   milestone-replace-text:
-  
+
+# Configuration values used when exporting release notes  
 export:
   include-created-date-in-title: false
   created-date-string-format:
   perform-regex-removal: false
   regex-text:
   multiline-regex: false
-  
+
+# The labels that will be used to include issues in release notes.
 issue-labels-include:
 - Bug
 - Feature
 - Improvement
 
+# The labels that will NOT be used when including issues in release notes.
 issue-labels-exclude:
 - Internal Refactoring
 
+# Overrides default pluralization and header names for specific labels.
 issue-labels-alias:
     - name:    Bug
       header:  Foo

--- a/Source/GitReleaseManager/Attributes/SampleAttribute.cs
+++ b/Source/GitReleaseManager/Attributes/SampleAttribute.cs
@@ -1,0 +1,15 @@
+﻿namespace GitReleaseManager.Core.Attributes
+{
+    using System;
+
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public sealed class SampleAttribute : Attribute
+    {
+        public SampleAttribute(object value)
+        {
+            this.Value = value;
+        }
+
+        public object Value { get; private set; }
+    }
+}

--- a/Source/GitReleaseManager/Configuration/CommentSerialization/CommentGatheringTypeInspector.cs
+++ b/Source/GitReleaseManager/Configuration/CommentSerialization/CommentGatheringTypeInspector.cs
@@ -1,0 +1,83 @@
+﻿// All of the classes in this file have been aquired from
+// https://dotnetfiddle.net/8M6iIE which was mentioned
+// on the YamlDotNet repository here: https://github.com/aaubry/YamlDotNet/issues/444#issuecomment-546709672
+
+namespace GitReleaseManager.Core.Configuration.CommentSerialization
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Linq;
+    using YamlDotNet.Core;
+    using YamlDotNet.Serialization;
+    using YamlDotNet.Serialization.TypeInspectors;
+
+    public sealed class CommentGatheringTypeInspector : TypeInspectorSkeleton
+    {
+        private readonly ITypeInspector innerTypeDescriptor;
+
+        public CommentGatheringTypeInspector(ITypeInspector innerTypeDescriptor)
+        {
+            if (innerTypeDescriptor == null)
+            {
+                throw new ArgumentNullException(nameof(innerTypeDescriptor));
+            }
+
+            this.innerTypeDescriptor = innerTypeDescriptor;
+        }
+
+        public override IEnumerable<IPropertyDescriptor> GetProperties(Type type, object container)
+        {
+            return this.innerTypeDescriptor.GetProperties(type, container).Select(d => new CommentsPropertyDescriptor(d));
+        }
+
+        private sealed class CommentsPropertyDescriptor : IPropertyDescriptor
+        {
+            private readonly IPropertyDescriptor baseDescriptor;
+
+            public CommentsPropertyDescriptor(IPropertyDescriptor baseDescriptor)
+            {
+                this.baseDescriptor = baseDescriptor;
+                Name = baseDescriptor.Name;
+            }
+
+            public string Name { get; set; }
+
+            public Type Type => this.baseDescriptor.Type;
+
+            public Type TypeOverride
+            {
+                get => this.baseDescriptor.TypeOverride;
+                set => this.baseDescriptor.TypeOverride = value;
+            }
+
+            public bool CanWrite => this.baseDescriptor.CanWrite;
+
+            public int Order { get; set; }
+
+            public ScalarStyle ScalarStyle
+            {
+                get => this.baseDescriptor.ScalarStyle;
+                set => this.baseDescriptor.ScalarStyle = value;
+            }
+
+            public T GetCustomAttribute<T>() where T : Attribute
+            {
+                return this.baseDescriptor.GetCustomAttribute<T>();
+            }
+
+            public IObjectDescriptor Read(object target)
+            {
+                var description = this.baseDescriptor.GetCustomAttribute<DescriptionAttribute>();
+                return description != null
+                    ? new CommentsObjectDescriptor(this.baseDescriptor.Read(target), description.Description)
+                    : this.baseDescriptor.Read(target);
+            }
+
+            public void Write(object target, object value)
+            {
+                this.baseDescriptor.Write(target, value);
+            }
+        }
+    }
+}

--- a/Source/GitReleaseManager/Configuration/CommentSerialization/CommentsObjectDescriptor.cs
+++ b/Source/GitReleaseManager/Configuration/CommentSerialization/CommentsObjectDescriptor.cs
@@ -1,0 +1,28 @@
+﻿// All of the classes in this file have been aquired from
+// https://dotnetfiddle.net/8M6iIE which was mentioned
+// on the YamlDotNet repository here: https://github.com/aaubry/YamlDotNet/issues/444#issuecomment-546709672
+
+namespace GitReleaseManager.Core.Configuration.CommentSerialization
+{
+    using System;
+    using YamlDotNet.Core;
+    using YamlDotNet.Serialization;
+
+    public sealed class CommentsObjectDescriptor : IObjectDescriptor
+    {
+        private readonly IObjectDescriptor innerDescriptor;
+
+        public CommentsObjectDescriptor(IObjectDescriptor innerDescriptor, string comment)
+        {
+            this.innerDescriptor = innerDescriptor;
+            Comment = comment;
+        }
+
+        public string Comment { get; private set; }
+
+        public object Value => this.innerDescriptor.Value;
+        public Type Type => this.innerDescriptor.Type;
+        public Type StaticType => this.innerDescriptor.StaticType;
+        public ScalarStyle ScalarStyle => this.innerDescriptor.ScalarStyle;
+    }
+}

--- a/Source/GitReleaseManager/Configuration/CommentSerialization/CommentsObjectGraphVisitor.cs
+++ b/Source/GitReleaseManager/Configuration/CommentSerialization/CommentsObjectGraphVisitor.cs
@@ -1,0 +1,30 @@
+﻿// All of the classes in this file have been aquired from
+// https://dotnetfiddle.net/8M6iIE which was mentioned
+// on the YamlDotNet repository here: https://github.com/aaubry/YamlDotNet/issues/444#issuecomment-546709672
+
+namespace GitReleaseManager.Core.Configuration.CommentSerialization
+{
+    using YamlDotNet.Core;
+    using YamlDotNet.Core.Events;
+    using YamlDotNet.Serialization;
+    using YamlDotNet.Serialization.ObjectGraphVisitors;
+
+    public sealed class CommentsObjectGraphVisitor : ChainedObjectGraphVisitor
+    {
+        public CommentsObjectGraphVisitor(IObjectGraphVisitor<IEmitter> nextVisitor)
+            : base(nextVisitor)
+        {
+        }
+
+        public override bool EnterMapping(IPropertyDescriptor key, IObjectDescriptor value, IEmitter context)
+        {
+            var commentsDescriptor = value as CommentsObjectDescriptor;
+            if (commentsDescriptor != null && commentsDescriptor.Comment != null)
+            {
+                context.Emit(new Comment(commentsDescriptor.Comment, false));
+            }
+
+            return base.EnterMapping(key, value, context);
+        }
+    }
+}

--- a/Source/GitReleaseManager/Configuration/Config.cs
+++ b/Source/GitReleaseManager/Configuration/Config.cs
@@ -7,6 +7,7 @@
 namespace GitReleaseManager.Core.Configuration
 {
     using System.Collections.Generic;
+    using System.ComponentModel;
     using YamlDotNet.Serialization;
 
     public class Config
@@ -55,18 +56,23 @@ namespace GitReleaseManager.Core.Configuration
             this.LabelAliases = new List<LabelAlias>();
         }
 
+        [Description("Configuration values used when creating new releases")]
         [YamlMember(Alias = "create")]
         public CreateConfig Create { get; private set; }
 
+        [Description("Configuration values used when exporting release notes")]
         [YamlMember(Alias = "export")]
         public ExportConfig Export { get; private set; }
 
+        [Description("The labels that will be used to include issues in release notes.")]
         [YamlMember(Alias = "issue-labels-include")]
         public IList<string> IssueLabelsInclude { get; private set; }
 
+        [Description("The labels that will NOT be used when including issues in release notes.")]
         [YamlMember(Alias = "issue-labels-exclude")]
         public IList<string> IssueLabelsExclude { get; private set; }
 
+        [Description("Overrides default pluralization and header names for specific labels.")]
         [YamlMember(Alias = "issue-labels-alias")]
         public IList<LabelAlias> LabelAliases { get; private set; }
     }

--- a/Source/GitReleaseManager/Configuration/ConfigSerializer.cs
+++ b/Source/GitReleaseManager/Configuration/ConfigSerializer.cs
@@ -10,6 +10,7 @@ namespace GitReleaseManager.Core.Configuration
     using System.IO;
     using System.Reflection;
     using GitReleaseManager.Core.Attributes;
+    using GitReleaseManager.Core.Configuration.CommentSerialization;
     using YamlDotNet.Serialization;
     using YamlDotNet.Serialization.NamingConventions;
 
@@ -32,6 +33,8 @@ namespace GitReleaseManager.Core.Configuration
         public static void Write(Config config, TextWriter writer)
         {
             var serializerBuilder = new SerializerBuilder()
+                .WithTypeInspector(inner => new CommentGatheringTypeInspector(inner))
+                .WithEmissionPhaseObjectGraphVisitor(args => new CommentsObjectGraphVisitor(args.InnerVisitor))
                 .WithNamingConvention(new HyphenatedNamingConvention())
                 .EmitDefaults(); // Can be removed when YamlDotNet is updated to 8.0.0+
             var serializer = serializerBuilder.Build();

--- a/Source/GitReleaseManager/Configuration/CreateConfig.cs
+++ b/Source/GitReleaseManager/Configuration/CreateConfig.cs
@@ -6,22 +6,27 @@
 
 namespace GitReleaseManager.Core.Configuration
 {
+    using GitReleaseManager.Core.Attributes;
     using YamlDotNet.Serialization;
 
     public class CreateConfig
     {
+        [Sample(true)]
         [YamlMember(Alias = "include-footer")]
         public bool IncludeFooter { get; set; }
 
+        [Sample("Where to get it")]
         [YamlMember(Alias = "footer-heading")]
         public string FooterHeading { get; set; }
 
+        [Sample("You can download this release from\n[chocolatey](https://chocolatey.org/packages/chocolateyGUI/{milestone})")]
         [YamlMember(Alias = "footer-content")]
         public string FooterContent { get; set; }
 
         [YamlMember(Alias = "footer-includes-milestone")]
         public bool FooterIncludesMilestone { get; set; }
 
+        [Sample("{milestone}")]
         [YamlMember(Alias = "milestone-replace-text")]
         public string MilestoneReplaceText { get; set; }
 

--- a/Source/GitReleaseManager/Configuration/ExportConfig.cs
+++ b/Source/GitReleaseManager/Configuration/ExportConfig.cs
@@ -6,6 +6,7 @@
 
 namespace GitReleaseManager.Core.Configuration
 {
+    using GitReleaseManager.Core.Attributes;
     using YamlDotNet.Serialization;
 
     public class ExportConfig
@@ -13,12 +14,14 @@ namespace GitReleaseManager.Core.Configuration
         [YamlMember(Alias = "include-created-date-in-title")]
         public bool IncludeCreatedDateInTitle { get; set; }
 
+        [Sample("MMMM dd, yyyy")]
         [YamlMember(Alias = "created-date-string-format")]
         public string CreatedDateStringFormat { get; set; }
 
         [YamlMember(Alias = "perform-regex-removal")]
         public bool PerformRegexRemoval { get; set; }
 
+        [Sample("### Where to get it(\\r\\n)*You can .*\\.")]
         [YamlMember(Alias = "regex-text")]
         public string RegexText { get; set; }
 


### PR DESCRIPTION
This PR will change create a sample yaml file with the following output.

<details>
<summary>Sample Output</summary>

```yaml
## Configuration values used when creating new releases
#create:
#  include-footer: true
#  footer-heading: Where to get it
#  footer-content: >-
#    You can download this release from
#
#    [chocolatey](https://chocolatey.org/packages/chocolateyGUI/{milestone})
#  footer-includes-milestone: false
#  milestone-replace-text: '{milestone}'
#  include-sha-section: false
#  sha-section-heading: SHA256 Hashes of the release artifacts
#  sha-section-line-format: '- `{1}	{0}`'
## Configuration values used when exporting release notes
#export:
#  include-created-date-in-title: false
#  created-date-string-format: MMMM dd, yyyy
#  perform-regex-removal: false
#  regex-text: '### Where to get it(\r\n)*You can .*\.'
#  multiline-regex: false
## The labels that will be used to include issues in release notes.
#issue-labels-include:
#- Bug
#- Duplicate
#- Enhancement
#- Feature
#- Help Wanted
#- Improvement
#- Invalid
#- Question
#- WontFix
## The labels that will NOT be used when including issues in release notes.
#issue-labels-exclude:
#- Internal Refactoring
## Overrides default pluralization and header names for specific labels.
#issue-labels-alias:
#- name: Documentation
#  header: Documentation
#  plural: Documentation
#
```

</details>

Unfortunately it also changes a little bit of the output from `showConfig` (basically adding the comments only). If this is not desirable, let me know and I will look into changing it.

<details>
<summary>Default `showConfig` output</summary>

```yaml
# Configuration values used when creating new releases
create:
  include-footer: false
  footer-heading: ''
  footer-content: ''
  footer-includes-milestone: false
  milestone-replace-text: ''
  include-sha-section: false
  sha-section-heading: SHA256 Hashes of the release artifacts
  sha-section-line-format: '- `{1}      {0}`'
# Configuration values used when exporting release notes
export:
  include-created-date-in-title: false
  created-date-string-format: ''
  perform-regex-removal: false
  regex-text: ''
  multiline-regex: false
# The labels that will be used to include issues in release notes.
issue-labels-include:
- Bug
- Duplicate
- Enhancement
- Feature
- Help Wanted
- Improvement
- Invalid
- Question
- WontFix
# The labels that will NOT be used when including issues in release notes.
issue-labels-exclude:
- Internal Refactoring
# Overrides default pluralization and header names for specific labels.
issue-labels-alias: []
```

</details>

resolves #151 