### PR TITLE
(maint) Fix warnings during building of GitReleaseManager

### DIFF
--- a/Source/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
+++ b/Source/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>GitReleaseManager</AssemblyName>
@@ -35,11 +35,6 @@
   </PropertyGroup>
   <Import Project="..\..\BuildScripts\CodeAnalysis.props" Condition="Exists('..\..\BuildScripts\CodeAnalysis.props')" />
   <Import Project="..\..\BuildScripts\StyleCop.props" Condition="Exists('..\..\BuildScripts\StyleCop.props')" />
-  <ItemGroup>
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SolutionInfo.cs" Link="SolutionInfo.cs" />
   </ItemGroup>

--- a/Source/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
+++ b/Source/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
@@ -33,8 +33,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <RunCodeAnalysisRestore>True</RunCodeAnalysisRestore>
   </PropertyGroup>
-  <Import Project="..\..\BuildScripts\CodeAnalysis.props" Condition="Exists('..\..\BuildScripts\CodeAnalysis.props')" />
-  <Import Project="..\..\BuildScripts\StyleCop.props" Condition="Exists('..\..\BuildScripts\StyleCop.props')" />
   <ItemGroup>
     <Compile Include="..\SolutionInfo.cs" Link="SolutionInfo.cs" />
   </ItemGroup>

--- a/Source/GitReleaseManager.Cli/GitReleaseManager.Tool.csproj
+++ b/Source/GitReleaseManager.Cli/GitReleaseManager.Tool.csproj
@@ -17,7 +17,7 @@
     <Description>Tool for creating and exporting releases for software applications hosted on GitHub.</Description>
     <Copyright>Copyright (c) 2015 - Present - GitTools Contributors</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageIconUrl>https://cdn.jsdelivr.net/gh/GitTools/GitReleaseManager@9c547452a10afaf83fce1b5833f4762487b017b7/Icons/package_icon.svg</PackageIconUrl>
+    <PackageIcon>package_icon.png</PackageIcon>
     <PackageReleaseNotes>https://github.com/GitTools/GitReleaseManager/releases</PackageReleaseNotes>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RepositoryType>git</RepositoryType>
@@ -47,5 +47,11 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Octokit" Version="0.32.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="../../Icons/package_icon.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 </Project>

--- a/Source/GitReleaseManager.Cli/GitReleaseManager.Tool.csproj
+++ b/Source/GitReleaseManager.Cli/GitReleaseManager.Tool.csproj
@@ -33,11 +33,6 @@
   <Import Project="..\..\BuildScripts\CodeAnalysis.props" Condition="Exists('..\..\BuildScripts\CodeAnalysis.props')" />
   <Import Project="..\..\BuildScripts\StyleCop.props" Condition="Exists('..\..\BuildScripts\StyleCop.props')" />
   <ItemGroup>
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="..\SolutionInfo.cs" Link="SolutionInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/GitReleaseManager.Cli/GitReleaseManager.Tool.csproj
+++ b/Source/GitReleaseManager.Cli/GitReleaseManager.Tool.csproj
@@ -30,8 +30,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <RunCodeAnalysisRestore>True</RunCodeAnalysisRestore>
   </PropertyGroup>
-  <Import Project="..\..\BuildScripts\CodeAnalysis.props" Condition="Exists('..\..\BuildScripts\CodeAnalysis.props')" />
-  <Import Project="..\..\BuildScripts\StyleCop.props" Condition="Exists('..\..\BuildScripts\StyleCop.props')" />
   <ItemGroup>
     <Compile Include="..\SolutionInfo.cs" Link="SolutionInfo.cs" />
   </ItemGroup>

--- a/Source/GitReleaseManager.Tests/ClipBoardHelper.cs
+++ b/Source/GitReleaseManager.Tests/ClipBoardHelper.cs
@@ -7,7 +7,7 @@
 namespace GitReleaseManager.Tests
 {
     using System.Threading;
-    using System.Windows.Forms;
+    using TextCopy;
 
     public class ClipBoardHelper
     {

--- a/Source/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
+++ b/Source/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp2.0</TargetFrameworks>
     <Title>GitReleaseManager.Tests</Title>
@@ -22,5 +22,6 @@
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
     <PackageReference Include="Octokit" Version="0.32.0" />
+    <PackageReference Include="TextCopy" Version="1.7.1" />
   </ItemGroup>
 </Project>

--- a/Source/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
+++ b/Source/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <Title>GitReleaseManager.Tests</Title>
@@ -10,12 +10,6 @@
     <Optimize>false</Optimize>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SolutionInfo.cs" Link="SolutionInfo.cs" />
   </ItemGroup>

--- a/Source/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
+++ b/Source/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp2.0</TargetFrameworks>
     <Title>GitReleaseManager.Tests</Title>
     <Description>Test Project for GitReleaseManager</Description>
     <DebugType>full</DebugType>

--- a/Source/GitReleaseManager/GitReleaseManager.Core.csproj
+++ b/Source/GitReleaseManager/GitReleaseManager.Core.csproj
@@ -17,8 +17,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <RunCodeAnalysisRestore>True</RunCodeAnalysisRestore>
   </PropertyGroup>
-  <Import Project="..\..\BuildScripts\CodeAnalysis.props" Condition="Exists('..\..\BuildScripts\CodeAnalysis.props')" />
-  <Import Project="..\..\BuildScripts\StyleCop.props" Condition="Exists('..\..\BuildScripts\StyleCop.props')" />
   <ItemGroup>
     <Compile Include="..\SolutionInfo.cs" Link="SolutionInfo.cs" />
   </ItemGroup>

--- a/Source/GitReleaseManager/GitReleaseManager.Core.csproj
+++ b/Source/GitReleaseManager/GitReleaseManager.Core.csproj
@@ -20,11 +20,6 @@
   <Import Project="..\..\BuildScripts\CodeAnalysis.props" Condition="Exists('..\..\BuildScripts\CodeAnalysis.props')" />
   <Import Project="..\..\BuildScripts\StyleCop.props" Condition="Exists('..\..\BuildScripts\StyleCop.props')" />
   <ItemGroup>
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="..\SolutionInfo.cs" Link="SolutionInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/nuspec/nuget/GitReleaseManager.nuspec
+++ b/nuspec/nuget/GitReleaseManager.nuspec
@@ -9,7 +9,7 @@
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/GitTools/GitReleaseManager</projectUrl>
     <repository type="git" url="https://github.com/GitTools/GitReleaseManager.git"/>
-    <iconUrl>https://cdn.jsdelivr.net/gh/GitTools/GitReleaseManager@9c547452a10afaf83fce1b5833f4762487b017b7/Icons/package_icon.svg</iconUrl>
+    <icon>package_icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Tool for creating and exporting releases for software applications hosted on GitHub</description>
     <summary>Tool for creating and exporting releases for software applications hosted on GitHub</summary>
@@ -23,5 +23,6 @@
     <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net451\GitReleaseManager.exe" target="tools" />
     <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net451\Octokit.dll" target="tools" />
     <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net451\YamlDotNet.dll" target="tools" />
+    <file src="..\..\Icons\package_icon.png" target="" />
   </files>
 </package>

--- a/recipe.cake
+++ b/recipe.cake
@@ -20,7 +20,7 @@ BuildParameters.PrintParameters(Context);
 ToolSettings.SetToolSettings(context: Context,
                             dupFinderExcludePattern: new string[] {
                                 BuildParameters.RootDirectoryPath + "/Source/GitReleaseManager.Tests/*.cs" },
-                            testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* -[Octokit]* -[YamlDotNet]* -[AlphaFS]* -[ApprovalTests]* -[ApprovalUtilities]*",
+                            testCoverageFilter: "+[GitReleaseManager*]* -[GitReleaseManager.Tests*]*",
                             testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
                             testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs");
 


### PR DESCRIPTION
This PR do the necessary work to remove almost all of the outputted warnings the occurs during building of GitReleaseManager.

There is one remaining warning (not counting those from Cake.Recipe) left that I have no idea of how to fix:

Issue from InspectCode:
```
Code Inspection Error(s) Located. Description:
File Name: ..\Packaging\nuget\GitReleaseManager.nuspec Line Number:  Message: No root tag defined
File Name: ..\Packaging\nuget\GitReleaseManager.Portable.nuspec Line Number:  Message: No root tag defined
```

THis issue also resolves issue #142 because it came up as a warning.