### PR TITLE
(GH-38) Add generation of logo during runtime

### DIFF
--- a/Source/GitReleaseManager.Cli/Options/BaseSubOptions.cs
+++ b/Source/GitReleaseManager.Cli/Options/BaseSubOptions.cs
@@ -15,5 +15,8 @@ namespace GitReleaseManager.Cli.Options
 
         [Option('l', "logFilePath", HelpText = "Path to where log file should be created. Defaults to logging to console.", Required = false)]
         public string LogFilePath { get; set; }
+
+        [Option("no-logo", HelpText = "Disables the generation of the GRM commandline logo.", Required = false)]
+        public bool NoLogo { get; set; }
     }
 }

--- a/Source/GitReleaseManager.Cli/Program.cs
+++ b/Source/GitReleaseManager.Cli/Program.cs
@@ -65,14 +65,31 @@ namespace GitReleaseManager.Cli
             {
                 version = version.Substring(0, version.IndexOf('+'));
             }
-            Console.WriteLine(@"
+            var shortFormat = @"
    ____ ____  __  __ 
   / ___|  _ \|  \/  |
  | |  _| |_) | |\/| |
  | |_| |  _ <| |  | |
   \____|_| \_\_|  |_|
 {0,21}
-", version);
+";
+            var longFormat = @"
+   ____ _ _   ____      _                     __  __
+  / ___(_) |_|  _ \ ___| | ___  __ _ ___  ___|  \/  | __ _ _ __   __ _  __ _  ___ _ __
+ | |  _| | __| |_) / _ \ |/ _ \/ _` / __|/ _ \ |\/| |/ _` | '_ \ / _` |/ _` |/ _ \ '__|
+ | |_| | | |_|  _ <  __/ |  __/ (_| \__ \  __/ |  | | (_| | | | | (_| | (_| |  __/ |
+  \____|_|\__|_| \_\___|_|\___|\__,_|___/\___|_|  |_|\__,_|_| |_|\__,_|\__, |\___|_|
+                                                                       |___/
+{0,87}
+";
+            if (Console.WindowWidth > 87)
+            {
+                Console.WriteLine(longFormat, version);
+            }
+            else
+            {
+                Console.WriteLine(shortFormat, version);
+            }
         }
 
         private static async Task<int> CreateReleaseAsync(CreateSubOptions subOptions)

--- a/Source/GitReleaseManager.Cli/Program.cs
+++ b/Source/GitReleaseManager.Cli/Program.cs
@@ -12,6 +12,7 @@ namespace GitReleaseManager.Cli
     using System.IO;
     using System.Linq;
     using System.Net;
+    using System.Reflection;
     using System.Security.Cryptography;
     using System.Text;
     using System.Threading.Tasks;
@@ -39,6 +40,7 @@ namespace GitReleaseManager.Cli
             _fileSystem = new FileSystem();
 
             return Parser.Default.ParseArguments<CreateSubOptions, AddAssetSubOptions, CloseSubOptions, PublishSubOptions, ExportSubOptions, InitSubOptions, ShowConfigSubOptions, LabelSubOptions>(args)
+                .WithParsed<BaseSubOptions>(CreateFiglet)
                 .MapResult(
                   (CreateSubOptions opts) => CreateReleaseAsync(opts).Result,
                   (AddAssetSubOptions opts) => AddAssetsAsync(opts).Result,
@@ -49,6 +51,28 @@ namespace GitReleaseManager.Cli
                   (ShowConfigSubOptions opts) => ShowConfig(opts),
                   (LabelSubOptions opts) => CreateLabelsAsync(opts).Result,
                   errs => 1);
+        }
+
+        private static void CreateFiglet(BaseSubOptions options)
+        {
+            if (options.NoLogo)
+            {
+                return;
+            }
+
+            var version = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            if (version.IndexOf('+') > 0)
+            {
+                version = version.Substring(0, version.IndexOf('+'));
+            }
+            Console.WriteLine(@"
+   ____ ____  __  __ 
+  / ___|  _ \|  \/  |
+ | |  _| |_) | |\/| |
+ | |_| |  _ <| |  | |
+  \____|_| \_\_|  |_|
+{0,21}
+", version);
         }
 
         private static async Task<int> CreateReleaseAsync(CreateSubOptions subOptions)


### PR DESCRIPTION
This commit will add GRM as a figlet logo
unless the user specifies the argument
'--no-logo' on the commandline.

There will also not be any generation of
the logo when the user requests the help
or version section of the program.

example with the current pr branch:

![logo sample](https://user-images.githubusercontent.com/1474648/69797177-8bd33a80-11cf-11ea-8641-9e76156231fe.png)


resolves #38