### PR TITLE
(GH-144) Add templates for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATES/bug_report.md
+++ b/.github/ISSUE_TEMPLATES/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Report a bug
+about: Create a bug report to help us improve
+title: 'REPLACE THIS TEXT WITH A GENERAL SUMMARY OF THE ISSUE'
+labels: Bug, Investigating
+assignees: ''
+---
+
+## Description
+<!-- Provide a more detailed introduction of the issue itself, -->
+<!-- and why you consider it to be a bug -->
+
+## Expected Behavior
+<!-- Tell us what you believe should happen -->
+
+## Actual Behavior
+<!-- Tell us what is happening> -->
+
+## Possible Fix
+<!-- Not obligatory, but suggest a fix or reason for the bug -->
+
+## Steps to Reproduce
+<!-- Provide a link to a live example, or an unambiguous set of steps to -->
+<!-- reproduce this bug. Include code to reproduce, if relevant -->
+
+## Context
+<!-- How has this bug affected you? What were you trying to accomplish? -->
+
+## Your Environment
+<!-- Include as many relevant details bout the environment -->
+<!-- you experienced the bug in -->
+- Version Used:
+- Edition Used (.NET Core, .NET Framework):
+- Operating System and version (Windows 10, Ubuntu 18.04):
+- Link to your project:
+- Link to your CI build (if appropriate):

--- a/.github/ISSUE_TEMPLATES/config.yml
+++ b/.github/ISSUE_TEMPLATES/config.yml
@@ -1,3 +1,4 @@
+blank_issues_enabled: false
 contact_links:
   - name: Gitter Community Chat
     url: https://gitter.im/GitTools/GitReleaseManager

--- a/.github/ISSUE_TEMPLATES/config.yml
+++ b/.github/ISSUE_TEMPLATES/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Gitter Community Chat
+    url: https://gitter.im/GitTools/GitReleaseManager
+    about: Plase ask and answer questions here.

--- a/.github/ISSUE_TEMPLATES/feature_request.md
+++ b/.github/ISSUE_TEMPLATES/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Suggest a new feature
+about: Suggest a new feature to implement
+title: 'REPLACE THIS TEXT WITH A GENERAL SUMMARY OF THE ISSUE'
+labels: Feature, Investigating
+assignees: ''
+---
+
+## Detailed Description
+<!--- Provide a detailed description of the change or addition you are proposing -->
+
+## Context
+<!--- Why is this change important to you? How would you use it? -->
+<!--- How can it benefit other users? -->
+
+## Possible Implementation
+<!--- Not obligatory, but suggest an idea for implementing addition or change -->
+
+## Your Environment
+<!--- Include as many relevant details about your environment -->
+- Version Used:
+- Edition Used (.NET Core, .NET Framework):
+- Operating System and version (Windows 10, Ubuntu 18.04):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Related Issue
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull requests adds a couple of missing issue templates, a pull request template, a link to the Gitter channel on the issue list and disables creation of blank issues.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #144 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To have a common template that can be used when creating issues/pull requests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
They haven't, but are similar to my own templates used in my projects.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. *(No code)*
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. *(No code, so no tests added)*
- [x] All new and existing tests passed. *(They should, no code changes have been implemented)*
