### PR TITLE
(GH-161) Better async

### DIFF
--- a/Source/GitReleaseManager.Cli/Program.cs
+++ b/Source/GitReleaseManager.Cli/Program.cs
@@ -114,11 +114,11 @@ namespace GitReleaseManager.Cli
                         releaseName = subOptions.Milestone;
                     }
 
-                    release = await _vcsProvider.CreateReleaseFromMilestone(subOptions.RepositoryOwner, subOptions.RepositoryName, subOptions.Milestone, releaseName, subOptions.TargetCommitish, subOptions.AssetPaths, subOptions.Prerelease);
+                    release = await _vcsProvider.CreateReleaseFromMilestone(subOptions.RepositoryOwner, subOptions.RepositoryName, subOptions.Milestone, releaseName, subOptions.TargetCommitish, subOptions.AssetPaths, subOptions.Prerelease).ConfigureAwait(false);
                 }
                 else
                 {
-                    release = await _vcsProvider.CreateReleaseFromInputFile(subOptions.RepositoryOwner, subOptions.RepositoryName, subOptions.Name, subOptions.InputFilePath, subOptions.TargetCommitish, subOptions.AssetPaths, subOptions.Prerelease);
+                    release = await _vcsProvider.CreateReleaseFromInputFile(subOptions.RepositoryOwner, subOptions.RepositoryName, subOptions.Name, subOptions.InputFilePath, subOptions.TargetCommitish, subOptions.AssetPaths, subOptions.Prerelease).ConfigureAwait(false);
                 }
 
                 Console.WriteLine(release.HtmlUrl);
@@ -160,7 +160,7 @@ namespace GitReleaseManager.Cli
 
                 _vcsProvider = GetVcsProvider(subOptions);
 
-                await _vcsProvider.AddAssets(subOptions.RepositoryOwner, subOptions.RepositoryName, subOptions.TagName, subOptions.AssetPaths);
+                await _vcsProvider.AddAssets(subOptions.RepositoryOwner, subOptions.RepositoryName, subOptions.TagName, subOptions.AssetPaths).ConfigureAwait(false);
 
                 return 0;
             }
@@ -180,7 +180,7 @@ namespace GitReleaseManager.Cli
 
                 _vcsProvider = GetVcsProvider(subOptions);
 
-                await _vcsProvider.CloseMilestone(subOptions.RepositoryOwner, subOptions.RepositoryName, subOptions.Milestone);
+                await _vcsProvider.CloseMilestone(subOptions.RepositoryOwner, subOptions.RepositoryName, subOptions.Milestone).ConfigureAwait(false);
 
                 return 0;
             }
@@ -200,7 +200,7 @@ namespace GitReleaseManager.Cli
 
                 _vcsProvider = GetVcsProvider(subOptions);
 
-                await _vcsProvider.PublishRelease(subOptions.RepositoryOwner, subOptions.RepositoryName, subOptions.TagName);
+                await _vcsProvider.PublishRelease(subOptions.RepositoryOwner, subOptions.RepositoryName, subOptions.TagName).ConfigureAwait(false);
 
                 return 0;
             }
@@ -220,7 +220,7 @@ namespace GitReleaseManager.Cli
 
                 _vcsProvider = GetVcsProvider(subOptions);
 
-                var releasesMarkdown = await _vcsProvider.ExportReleases(subOptions.RepositoryOwner, subOptions.RepositoryName, subOptions.TagName);
+                var releasesMarkdown = await _vcsProvider.ExportReleases(subOptions.RepositoryOwner, subOptions.RepositoryName, subOptions.TagName).ConfigureAwait(false);
 
                 using (var sw = new StreamWriter(File.Open(subOptions.FileOutputPath, FileMode.OpenOrCreate)))
                 {
@@ -261,7 +261,7 @@ namespace GitReleaseManager.Cli
 
                 _vcsProvider = GetVcsProvider(subOptions);
 
-                await _vcsProvider.CreateLabels(subOptions.RepositoryOwner, subOptions.RepositoryName);
+                await _vcsProvider.CreateLabels(subOptions.RepositoryOwner, subOptions.RepositoryName).ConfigureAwait(false);
 
                 return 0;
             }

--- a/Source/GitReleaseManager.Cli/Program.cs
+++ b/Source/GitReleaseManager.Cli/Program.cs
@@ -50,8 +50,8 @@ namespace GitReleaseManager.Cli
                   (CloseSubOptions opts) => CloseMilestoneAsync(opts),
                   (PublishSubOptions opts) => PublishReleaseAsync(opts),
                   (ExportSubOptions opts) => ExportReleasesAsync(opts),
-                  (InitSubOptions opts) => CreateSampleConfigFile(opts),
-                  (ShowConfigSubOptions opts) => ShowConfig(opts),
+                  (InitSubOptions opts) => CreateSampleConfigFileAsync(opts),
+                  (ShowConfigSubOptions opts) => ShowConfigAsync(opts),
                   (LabelSubOptions opts) => CreateLabelsAsync(opts),
                   errs => Task.FromResult(1));
         }
@@ -235,7 +235,7 @@ namespace GitReleaseManager.Cli
             }
         }
 
-        private static Task<int> CreateSampleConfigFile(InitSubOptions subOptions)
+        private static Task<int> CreateSampleConfigFileAsync(InitSubOptions subOptions)
         {
             ConfigureLogging(subOptions.LogFilePath);
 
@@ -243,7 +243,7 @@ namespace GitReleaseManager.Cli
             return Task.FromResult(0);
         }
 
-        private static Task<int> ShowConfig(ShowConfigSubOptions subOptions)
+        private static Task<int> ShowConfigAsync(ShowConfigSubOptions subOptions)
         {
             ConfigureLogging(subOptions.LogFilePath);
 

--- a/Source/GitReleaseManager.Cli/Program.cs
+++ b/Source/GitReleaseManager.Cli/Program.cs
@@ -41,7 +41,7 @@ namespace GitReleaseManager.Cli
 
             _mapper = AutoMapperConfiguration.Configure();
             
-            var result = Parser.Default.ParseArguments<CreateSubOptions, DiscardSubOptions, AddAssetSubOptions, CloseSubOptions, PublishSubOptions, ExportSubOptions, InitSubOptions, ShowConfigSubOptions, LabelSubOptions>(args)
+            return Parser.Default.ParseArguments<CreateSubOptions, DiscardSubOptions, AddAssetSubOptions, CloseSubOptions, PublishSubOptions, ExportSubOptions, InitSubOptions, ShowConfigSubOptions, LabelSubOptions>(args)
                 .WithParsed<BaseSubOptions>(CreateFiglet)
                 .MapResult(
                   (CreateSubOptions opts) => CreateReleaseAsync(opts),
@@ -50,12 +50,10 @@ namespace GitReleaseManager.Cli
                   (CloseSubOptions opts) => CloseMilestoneAsync(opts),
                   (PublishSubOptions opts) => PublishReleaseAsync(opts),
                   (ExportSubOptions opts) => ExportReleasesAsync(opts),
-                  (InitSubOptions opts) => Task.FromResult(CreateSampleConfigFile(opts)),
-                  (ShowConfigSubOptions opts) => Task.FromResult(ShowConfig(opts)),
+                  (InitSubOptions opts) => CreateSampleConfigFile(opts),
+                  (ShowConfigSubOptions opts) => ShowConfig(opts),
                   (LabelSubOptions opts) => CreateLabelsAsync(opts),
                   errs => Task.FromResult(1));
-
-            return result;
         }
 
         private static void CreateFiglet(BaseSubOptions options)
@@ -237,20 +235,20 @@ namespace GitReleaseManager.Cli
             }
         }
 
-        private static int CreateSampleConfigFile(InitSubOptions subOptions)
+        private static Task<int> CreateSampleConfigFile(InitSubOptions subOptions)
         {
             ConfigureLogging(subOptions.LogFilePath);
 
             ConfigurationProvider.WriteSample(subOptions.TargetDirectory ?? Environment.CurrentDirectory, _fileSystem);
-            return 0;
+            return Task.FromResult(0);
         }
 
-        private static int ShowConfig(ShowConfigSubOptions subOptions)
+        private static Task<int> ShowConfig(ShowConfigSubOptions subOptions)
         {
             ConfigureLogging(subOptions.LogFilePath);
 
             Console.WriteLine(ConfigurationProvider.GetEffectiveConfigAsString(subOptions.TargetDirectory ?? Environment.CurrentDirectory, _fileSystem));
-            return 0;
+            return Task.FromResult(0);
         }
 
         private static async Task<int> CreateLabelsAsync(LabelSubOptions subOptions)

--- a/Source/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
+++ b/Source/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
-    <TargetFrameworks>net472;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
     <Title>GitReleaseManager.Tests</Title>
     <Description>Test Project for GitReleaseManager</Description>
     <DebugType>full</DebugType>

--- a/Source/GitReleaseManager.Tests/ReleaseNotesBuilderIntegrationTests.cs
+++ b/Source/GitReleaseManager.Tests/ReleaseNotesBuilderIntegrationTests.cs
@@ -18,12 +18,17 @@ namespace GitReleaseManager.Tests
     [TestFixture]
     public class ReleaseNotesBuilderIntegrationTests
     {
+        public TestContext TestContext { get; set; }
+
         private IMapper _mapper;
 
         [OneTimeSetUp]
         public void Configure()
         {
             _mapper = AutoMapperConfiguration.Configure();
+            Logger.WriteError = s => TestContext.WriteLine($"Error: {s}");
+            Logger.WriteInfo = s => TestContext.WriteLine($"Info: {s}");
+            Logger.WriteWarning = s => TestContext.WriteLine($"Warning: {s}");
         }
 
         [Test]

--- a/Source/GitReleaseManager/GitHubProvider.cs
+++ b/Source/GitReleaseManager/GitHubProvider.cs
@@ -276,13 +276,11 @@ namespace GitReleaseManager.Core
             }
         }
 
-        public async Task<string> ExportReleases(string owner, string repository, string tagName)
+        public Task<string> ExportReleases(string owner, string repository, string tagName)
         {
             var releaseNotesExporter = new ReleaseNotesExporter(this, _configuration, owner, repository);
 
-            var result = await releaseNotesExporter.ExportReleaseNotes(tagName).ConfigureAwait(false);
-
-            return result;
+            return releaseNotesExporter.ExportReleaseNotes(tagName);
         }
 
         public async Task CloseMilestone(string owner, string repository, string milestoneTitle)

--- a/Source/GitReleaseManager/GitHubProvider.cs
+++ b/Source/GitReleaseManager/GitHubProvider.cs
@@ -213,9 +213,7 @@ namespace GitReleaseManager.Core
         }
         public async Task AddAssets(string owner, string repository, string tagName, IList<string> assets)
         {
-            var releases = await _gitHubClient.Repository.Release.GetAll(owner, repository).ConfigureAwait(false);
-
-            var release = releases.FirstOrDefault(r => r.TagName == tagName);
+            var release = await GetRelease(owner, repository, tagName).ConfigureAwait(false);
 
             if (release == null)
             {
@@ -300,8 +298,7 @@ namespace GitReleaseManager.Core
 
         public async Task PublishRelease(string owner, string repository, string tagName)
         {
-            var releases = await _gitHubClient.Repository.Release.GetAll(owner, repository).ConfigureAwait(false);
-            var release = releases.FirstOrDefault(r => r.TagName == tagName);
+            var release = await GetRelease(owner, repository, tagName).ConfigureAwait(false);
 
             if (release == null)
             {
@@ -334,6 +331,13 @@ namespace GitReleaseManager.Core
 
             var createLabelsTasks = newLabels.Select(label => _gitHubClient.Issue.Labels.Create(owner, repository, label));
             await Task.WhenAll(createLabelsTasks).ConfigureAwait(false);
+        }
+
+        private async Task<Octokit.Release> GetRelease(string owner, string repository, string tagName)
+        {
+            var releases = await _gitHubClient.Repository.Release.GetAll(owner, repository).ConfigureAwait(false);
+            var release = releases.FirstOrDefault(r => r.TagName == tagName);
+            return release;
         }
     }
 }

--- a/Source/GitReleaseManager/GitHubProvider.cs
+++ b/Source/GitReleaseManager/GitHubProvider.cs
@@ -329,15 +329,11 @@ namespace GitReleaseManager.Core
 
             var labels = await _gitHubClient.Issue.Labels.GetAllForRepository(owner, repository).ConfigureAwait(false);
 
-            foreach (var label in labels)
-            {
-                await _gitHubClient.Issue.Labels.Delete(owner, repository, label.Name).ConfigureAwait(false);
-            }
+            var deleteLabelsTasks = labels.Select(label => _gitHubClient.Issue.Labels.Delete(owner, repository, label.Name));
+            await Task.WhenAll(deleteLabelsTasks).ConfigureAwait(false);
 
-            foreach (var label in newLabels)
-            {
-                await _gitHubClient.Issue.Labels.Create(owner, repository, label).ConfigureAwait(false);
-            }
+            var createLabelsTasks = newLabels.Select(label => _gitHubClient.Issue.Labels.Create(owner, repository, label));
+            await Task.WhenAll(createLabelsTasks).ConfigureAwait(false);
         }
     }
 }

--- a/Source/GitReleaseManager/OctokitExtensions.cs
+++ b/Source/GitReleaseManager/OctokitExtensions.cs
@@ -42,8 +42,8 @@ namespace GitReleaseManager.Core
             var parts = milestone.Url.Split('/');
             var user = parts[4];
             var repository = parts[5];
-            var closedIssues = await gitHubClient.Issue.GetAllForRepository(user, repository, closedIssueRequest);
-            var openIssues = await gitHubClient.Issue.GetAllForRepository(user, repository, openIssueRequest);
+            var closedIssues = await gitHubClient.Issue.GetAllForRepository(user, repository, closedIssueRequest).ConfigureAwait(false);
+            var openIssues = await gitHubClient.Issue.GetAllForRepository(user, repository, openIssueRequest).ConfigureAwait(false);
             
             return openIssues.Union(closedIssues);
         }

--- a/Source/GitReleaseManager/ReleaseNotesBuilder.cs
+++ b/Source/GitReleaseManager/ReleaseNotesBuilder.cs
@@ -40,10 +40,10 @@ namespace GitReleaseManager.Core
             LoadMilestones();
             GetTargetMilestone();
 
-            var issues = await GetIssues(_targetMilestone);
+            var issues = await GetIssues(_targetMilestone).ConfigureAwait(false);
             var stringBuilder = new StringBuilder();
             var previousMilestone = GetPreviousMilestone();
-            var numberOfCommits = await _vcsProvider.GetNumberOfCommitsBetween(previousMilestone, _targetMilestone, _user, _repository);
+            var numberOfCommits = await _vcsProvider.GetNumberOfCommitsBetween(previousMilestone, _targetMilestone, _user, _repository).ConfigureAwait(false);
 
             if (issues.Count > 0)
             {
@@ -175,7 +175,7 @@ namespace GitReleaseManager.Core
 
         private async Task<List<Issue>> GetIssues(Milestone milestone)
         {
-            var issues = await _vcsProvider.GetIssues(milestone);
+            var issues = await _vcsProvider.GetIssues(milestone).ConfigureAwait(false);
             foreach (var issue in issues)
             {
                 CheckForValidLabels(issue);

--- a/Source/GitReleaseManager/ReleaseNotesExporter.cs
+++ b/Source/GitReleaseManager/ReleaseNotesExporter.cs
@@ -36,7 +36,7 @@ namespace GitReleaseManager.Core
 
             if (string.IsNullOrEmpty(tagName))
             {
-                var releases = await _vcsProvider.GetReleases(_user, _repository);
+                var releases = await _vcsProvider.GetReleases(_user, _repository).ConfigureAwait(false);
 
                 if (releases.Count > 0)
                 {
@@ -52,7 +52,7 @@ namespace GitReleaseManager.Core
             }
             else
             {
-                var release = await _vcsProvider.GetSpecificRelease(tagName, _user, _repository);
+                var release = await _vcsProvider.GetSpecificRelease(tagName, _user, _repository).ConfigureAwait(false);
 
                 AppendVersionReleaseNotes(stringBuilder, release);
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The GitReleaseManager is doing a lot of context switching when executing async methods.
Also calling `.Result` on Tasks is generally bad practice.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#161 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes bad practices when using Tasks. This PR tries to solve:
- Stack traces being 💩 when there is an unhandled exception due to calling .Result on Tasks
- Methods are context switching a lot, leading to potential issues, if thread a Task tries to switch back to is blocked, leading to dead-locks
- Going async from entry point and all the way through the tool

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the test suite and ran the CLI tool to verify it still works.

## Screenshots (if appropriate):
![unittests](https://user-images.githubusercontent.com/249719/70481448-e713ff80-1ae2-11ea-83a9-2b3529fc02e5.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
