### PR TITLE
(GH-128) Add the ability to comment on issues during publish

### DIFF
--- a/Source/GitReleaseManager.Tests/Extensions/StringExtensionsTests.cs
+++ b/Source/GitReleaseManager.Tests/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,60 @@
+// -----------------------------------------------------------------------
+// <copyright file="StringExtensionsTests.cs" company="GitTools Contributors">
+// Copyright (c) 2015 - Present - GitTools Contributors
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace GitReleaseManager.Tests.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using GitReleaseManager.Core.Extensions;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class StringExtensionsTests
+    {
+        [Test]
+        public void Should_Replace_Variables_In_String()
+        {
+            const string expected = "This test was created by AdmiringWorm for GitReleaseManager.";
+            const string textToTest = "This test was created by {User} for {Program}.";
+            var variables = new { User = "AdmiringWorm", Program = "GitReleaseManager" };
+
+            var actual = textToTest.ReplaceTemplate(variables);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Should_Replace_Variables_In_String_When_Case_Differs()
+        {
+            const string expected = "This test was created by AdmiringWorm for GitReleaseManager.";
+            const string textToTest = "This test was created by {USeR} for {Program}.";
+            var variables = new { User = "AdmiringWorm", ProgrAM = "GitReleaseManager" };
+
+            var actual = textToTest.ReplaceTemplate(variables);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Should_Replace_Variables_When_Dictionary_Is_Used()
+        {
+            const string expected = "This test was created by AdmiringWorm for GitReleaseManager.";
+            const string textToTest = "This test was created by {User} for {Program}.";
+            var variables = new Dictionary<string, object>
+            {
+                { "User", "AdmiringWorm" },
+                { "Program", "GitReleaseManager" },
+            };
+
+            var actual = textToTest.ReplaceTemplate(variables);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+    }
+}

--- a/Source/GitReleaseManager/Configuration/CloseConfig.cs
+++ b/Source/GitReleaseManager/Configuration/CloseConfig.cs
@@ -1,0 +1,32 @@
+// -----------------------------------------------------------------------
+// <copyright file="CloseConfig.cs" company="GitTools Contributors">
+// Copyright (c) 2015 - Present - GitTools Contributors
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace GitReleaseManager.Core.Configuration
+{
+    using System.ComponentModel;
+    using GitReleaseManager.Core.Attributes;
+    using YamlDotNet.Serialization;
+
+    /// <summary>
+    /// Class for holding configuration values used during milestone closing. This class cannot be inherited.
+    /// </summary>
+    public sealed class CloseConfig
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether adding issue comments is enabled or not.
+        /// </summary>
+        [Description("Whether to add comments to issues closed and with the published milestone release.")]
+        [YamlMember(Alias = "use-issue-comments")]
+        public bool IssueComments { get; set; }
+
+        /// <summary>
+        /// Gets or sets the issue comment format to use when commenting on issues.
+        /// </summary>
+        [Sample(":tada: This issue has been resolved in version {milestone} :tada:\n\nThe release is available on:\n\n- [NuGet package(@{milestone})](https://nuget.org/packages/{repository}/{milestone})\n- [GitHub release](https://github.com/{owner}/{repository}/releases/tag/{milestone})\n\nYour **[GitReleaseManager](https://github.com/GitTools/GitReleaseManager)** bot :package::rocket:")]
+        [YamlMember(Alias = "issue-comment", ScalarStyle = YamlDotNet.Core.ScalarStyle.Literal)]
+        public string IssueCommentFormat { get; set; }
+    }
+}

--- a/Source/GitReleaseManager/Configuration/Config.cs
+++ b/Source/GitReleaseManager/Configuration/Config.cs
@@ -35,6 +35,18 @@ namespace GitReleaseManager.Core.Configuration
                 IsMultilineRegex = false,
             };
 
+            Close = new CloseConfig
+            {
+                IssueComments = false,
+                IssueCommentFormat = @":tada: This issue has been resolved in version {milestone} :tada:
+
+The release is available on:
+
+- [GitHub release](https://github.com/{owner}/{repository}/releases/tag/{milestone})
+
+Your **[GitReleaseManager](https://github.com/GitTools/GitReleaseManager)** bot :package::rocket:",
+            };
+
             IssueLabelsInclude = new List<string>
                                    {
                                        "Bug",
@@ -63,6 +75,13 @@ namespace GitReleaseManager.Core.Configuration
         [Description("Configuration values used when exporting release notes")]
         [YamlMember(Alias = "export")]
         public ExportConfig Export { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the close configuration values.
+        /// </summary>
+        [Description("Configuration values used when closing a milestone")]
+        [YamlMember(Alias = "close")]
+        public CloseConfig Close { get; set; }
 
         [Description("The labels that will be used to include issues in release notes.")]
         [YamlMember(Alias = "issue-labels-include")]

--- a/Source/GitReleaseManager/Configuration/Config.cs
+++ b/Source/GitReleaseManager/Configuration/Config.cs
@@ -12,6 +12,14 @@ namespace GitReleaseManager.Core.Configuration
 
     public class Config
     {
+        internal const string IssueCommentFormat = @":tada: This issue has been resolved in version {milestone} :tada:
+
+The release is available on:
+
+- [GitHub release](https://github.com/{owner}/{repository}/releases/tag/{milestone})
+
+Your **[GitReleaseManager](https://github.com/GitTools/GitReleaseManager)** bot :package::rocket:";
+
         public Config()
         {
             Create = new CreateConfig
@@ -38,13 +46,7 @@ namespace GitReleaseManager.Core.Configuration
             Close = new CloseConfig
             {
                 IssueComments = false,
-                IssueCommentFormat = @":tada: This issue has been resolved in version {milestone} :tada:
-
-The release is available on:
-
-- [GitHub release](https://github.com/{owner}/{repository}/releases/tag/{milestone})
-
-Your **[GitReleaseManager](https://github.com/GitTools/GitReleaseManager)** bot :package::rocket:",
+                IssueCommentFormat = IssueCommentFormat,
             };
 
             IssueLabelsInclude = new List<string>

--- a/Source/GitReleaseManager/Configuration/ConfigurationProvider.cs
+++ b/Source/GitReleaseManager/Configuration/ConfigurationProvider.cs
@@ -93,6 +93,11 @@ namespace GitReleaseManager.Core.Configuration
             {
                 configuration.Create.ShaSectionLineFormat = "- `{1}\t{0}`";
             }
+
+            if (configuration.Close.IssueCommentFormat == null)
+            {
+                configuration.Close.IssueCommentFormat = Config.IssueCommentFormat;
+            }
         }
     }
 }

--- a/Source/GitReleaseManager/Extensions/StringExtensions.cs
+++ b/Source/GitReleaseManager/Extensions/StringExtensions.cs
@@ -1,0 +1,59 @@
+// -----------------------------------------------------------------------
+// <copyright file="StringExtensions.cs" company="GitTools Contributors">
+// Copyright (c) 2015 - Present - GitTools Contributors
+// </copyright>
+// -----------------------------------------------------------------------
+
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("GitReleaseManager.Tests")]
+
+namespace GitReleaseManager.Core.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
+    internal static class StringExtensions
+    {
+        public static string ReplaceTemplate(this string source, object values)
+        {
+            IDictionary<string, object> pairs;
+
+            if (values is IDictionary<string, object> dict)
+            {
+                pairs = new Dictionary<string, object>(dict, StringComparer.OrdinalIgnoreCase);
+            }
+            else
+            {
+                var type = values.GetType();
+                var properties = type.GetProperties();
+                pairs = properties.ToDictionary(x => x.Name, x => x.GetValue(values), StringComparer.OrdinalIgnoreCase);
+            }
+
+            var sb = new StringBuilder();
+            int i, prevI = 0;
+            while ((i = source.IndexOf('{', prevI)) >= 0)
+            {
+                sb.Append(source.Substring(prevI, i - prevI));
+                prevI = i + 1;
+                if ((i = source.IndexOf('}', prevI)) > prevI)
+                {
+                    var name = source.Substring(prevI, i - prevI);
+                    if (pairs.ContainsKey(name))
+                    {
+                        sb.Append(pairs[name]);
+                    }
+
+                    prevI = ++i;
+                }
+            }
+
+            if (source.Length > prevI)
+            {
+                sb.Append(source.Substring(prevI, source.Length - prevI));
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Source/GitReleaseManager/GitHubProvider.cs
+++ b/Source/GitReleaseManager/GitHubProvider.cs
@@ -380,6 +380,11 @@ namespace GitReleaseManager.Core
 
             foreach (var issue in issues)
             {
+                if (issue.State != ItemState.Closed)
+                {
+                    continue;
+                }
+
                 SleepWhenRateIsLimited();
 
                 Logger.WriteInfo(string.Format("Adding published comment for issue #{0}", issue.Number));

--- a/Source/GitReleaseManager/ReleaseNotesBuilder.cs
+++ b/Source/GitReleaseManager/ReleaseNotesBuilder.cs
@@ -14,6 +14,7 @@ namespace GitReleaseManager.Core
     using System.Text;
     using System.Threading.Tasks;
     using GitReleaseManager.Core.Configuration;
+    using GitReleaseManager.Core.Extensions;
     using GitReleaseManager.Core.Model;
 
     public class ReleaseNotesBuilder
@@ -160,7 +161,11 @@ namespace GitReleaseManager.Core
             {
                 if (!string.IsNullOrEmpty(_configuration.Create.MilestoneReplaceText))
                 {
-                    footerContent = footerContent.Replace(_configuration.Create.MilestoneReplaceText, _milestoneTitle);
+                    var replaceValues = new Dictionary<string, object>
+                    {
+                        { _configuration.Create.MilestoneReplaceText.Trim('{', '}'), _milestoneTitle },
+                    };
+                    footerContent = footerContent.ReplaceTemplate(replaceValues);
                 }
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the ability to add a comment on closed issues (for a milestone/tag name) during the release publishing process.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #128 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The motivation is to allow users of GRM to update users posting fixed issues that the changes is now part of the new release.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running GRM Locally, see the last comments on the following issues in a test repository: https://github.com/AdmiringWorm/FakeTestRepository/issues

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. (Not completely sure if changes are needed)
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes. (Partially, not sure how to add changes for the github client specific changes)
- [x] All new and existing tests passed.

## Additional Notes

I was a little unsure if the place to add this code should be during publishing, or during the closing of the milestone.
For now, I have added it during publishing but can change it to closing if that is more appropriate.