### PR TITLE
(GH-140) Add integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -323,3 +323,7 @@ BuildArtifacts/*
 config.wyam.dll
 config.wyam.hash
 config.wyam.packages.xml
+
+# Integration Tests
+tests/integration/tools
+tests/integration/output

--- a/recipe.cake
+++ b/recipe.cake
@@ -11,7 +11,9 @@ BuildParameters.SetParameters(context: Context,
                             repositoryName: "GitReleaseManager",
                             appVeyorAccountName: "GitTools",
                             shouldRunGitVersion: true,
-                            shouldRunDotNetCorePack: true);
+                            shouldRunDotNetCorePack: true,
+                            shouldRunIntegrationTests: true,
+                            integrationTestScriptPath: "./tests/integration/tests.cake");
 
 BuildParameters.PackageSources.Add(new PackageSourceData(Context, "GPR", "https://nuget.pkg.github.com/GitTools/index.json", FeedType.NuGet, false));
 

--- a/tests/integration/buildData.cake
+++ b/tests/integration/buildData.cake
@@ -1,0 +1,24 @@
+public class BuildData
+{
+    public string GitHubUsername { get; }
+    public string GitHubPassword { get; }
+    public string GitHubToken { get; }
+    public string GitHubOwner { get; }
+    public string GitHubRepository { get; }
+    public string GrmMilestone { get; }
+
+    public BuildData(ICakeContext context)
+    {
+        if (context == null)
+        {
+            throw new ArgumentException(nameof(context));
+        }
+
+        GitHubUsername = context.EnvironmentVariable("GITTOOLS_GITHUB_USERNAME");
+        GitHubPassword = context.EnvironmentVariable("GITTOOLS_GITHUB_PASSWORD");
+        GitHubToken = context.EnvironmentVariable("GITTOOLS_GITHUB_TOKEN");
+        GitHubOwner = "gep13";
+        GitHubRepository = "FakeRepository";
+        GrmMilestone = "v0.1.2";
+    }
+}

--- a/tests/integration/expected/releasenotes-with-token.md
+++ b/tests/integration/expected/releasenotes-with-token.md
@@ -1,0 +1,11 @@
+## v0.1.2
+
+
+As part of this release we had [8 commits](https://github.com/gep13/FakeRepository/compare/v0.1.1...v0.1.2) which resulted in [1 issue](https://github.com/GitTools/FakeRepository/milestone/2?closed=1) being closed.
+
+
+__Bug__
+
+- [__#3__](https://github.com/GitTools/FakeRepository/issues/3) Test
+
+

--- a/tests/integration/expected/releasenotes-with-username-password.md
+++ b/tests/integration/expected/releasenotes-with-username-password.md
@@ -1,0 +1,11 @@
+## v0.1.2
+
+
+As part of this release we had [8 commits](https://github.com/gep13/FakeRepository/compare/v0.1.1...v0.1.2) which resulted in [1 issue](https://github.com/GitTools/FakeRepository/milestone/2?closed=1) being closed.
+
+
+__Bug__
+
+- [__#3__](https://github.com/GitTools/FakeRepository/issues/3) Test
+
+

--- a/tests/integration/tests.cake
+++ b/tests/integration/tests.cake
@@ -1,0 +1,247 @@
+#load "buildData.cake"
+#load "xunit.cake"
+#load "utilities.cake"
+
+var target = Argument<string>("target", "Run-All-Tests");
+
+Setup<BuildData>(ctx =>
+{
+    var buildDir = "../../BuildArtifacts/temp/_PublishedApplications";
+    var grmExecutable = ctx.GetFiles(buildDir + "/**/*.exe").First();
+
+	ctx.Information("Registering Built GRM executable...");
+	ctx.Tools.RegisterFile(grmExecutable);
+
+    CleanDirectory("./output");
+
+    return new BuildData(ctx);
+});
+
+Task("Create-Release-With-Username-Password")
+    .Does<BuildData>((data) =>
+{
+    GitReleaseManagerCreate(
+        data.GitHubUsername,
+        data.GitHubPassword,
+        data.GitHubOwner,
+        data.GitHubRepository,
+        new GitReleaseManagerCreateSettings {
+            Milestone         = data.GrmMilestone,
+            TargetCommitish   = "master"
+        });
+});
+
+Task("Create-Release-With-Token")
+    .Does<BuildData>((data) =>
+{
+    GitReleaseManagerCreate(
+        data.GitHubToken,
+        data.GitHubOwner,
+        data.GitHubRepository,
+        new GitReleaseManagerCreateSettings {
+            Milestone         = data.GrmMilestone,
+            TargetCommitish   = "master"
+        });
+});
+
+Task("Add-Asset-To-Release-With-Username-Password")
+    .Does(() =>
+{
+  // Without running something like Octokit directly against the draft release,
+  // not sure how to verify that the assets get added as expected.
+});
+
+Task("Add-Asset-To-Release-With-Token")
+    .Does(() =>
+{
+  // Without running something like Octokit directly against the draft release,
+  // not sure how to verify that the assets get added as expected.
+});
+
+Task("Export-Release-With-Username-Password")
+    .Does<BuildData>((data) =>
+{
+    GitReleaseManagerExport(
+        data.GitHubToken,
+        data.GitHubOwner,
+        data.GitHubRepository,
+        "./output/releasenotes-with-username-password.md",
+        new GitReleaseManagerExportSettings {
+            TagName = data.GrmMilestone
+        });
+
+    // Then
+    Assert.True(FileExists("./output/releasenotes-with-username-password.md"));
+    Assert.True(FileHashEquals("./expected/releasenotes-with-username-password.md", "./output/releasenotes-with-username-password.md"));
+});
+
+Task("Export-Release-With-Token")
+    .Does<BuildData>((data) =>
+{
+    GitReleaseManagerExport(
+        data.GitHubUsername,
+        data.GitHubPassword,
+        data.GitHubOwner,
+        data.GitHubRepository,
+        "./output/releasenotes-with-token.md",
+        new GitReleaseManagerExportSettings {
+            TagName = data.GrmMilestone
+        });
+
+    // Then
+    Assert.True(FileExists("./output/releasenotes-with-token.md"));
+    Assert.True(FileHashEquals("./expected/releasenotes-with-token.md", "./output/releasenotes-with-token.md"));
+});
+
+Task("Close-Milestone-With-Username-Password")
+    .Does<BuildData>((data) =>
+{
+    GitReleaseManagerClose(
+        data.GitHubUsername,
+        data.GitHubPassword,
+        data.GitHubOwner,
+        data.GitHubRepository,
+        data.GrmMilestone
+    );
+});
+
+Task("Close-Milestone-With-Token")
+    .Does<BuildData>((data) =>
+{
+    GitReleaseManagerClose(
+        data.GitHubToken,
+        data.GitHubOwner,
+        data.GitHubRepository,
+        data.GrmMilestone
+    );
+});
+
+Task("Discard-Release-With-Username-Password")
+    .Does<BuildData>((data) =>
+{
+    var settings = new GitReleaseManagerCreateSettings();
+    settings.Milestone = data.GrmMilestone;
+
+    // TODO: This can be replaced when a discard alias is added to Cake
+    settings.ArgumentCustomization = args => {
+        var newArgs = new ProcessArgumentBuilder()
+                        .Append("discard");
+
+        Array.ForEach(
+            args.Skip(1).ToArray(),
+            newArgs.Append
+            );
+
+        return newArgs;
+    };
+
+    GitReleaseManagerCreate(
+        data.GitHubUsername,
+        data.GitHubPassword,
+        data.GitHubOwner,
+        data.GitHubRepository,
+        settings);
+});
+
+Task("Discard-Release-With-Token")
+    .Does<BuildData>((data) =>
+{
+    var settings = new GitReleaseManagerCreateSettings();
+    settings.Milestone = data.GrmMilestone;
+
+    // TODO: This can be replaced when a discard alias is added to Cake
+    settings.ArgumentCustomization = args => {
+        var newArgs = new ProcessArgumentBuilder()
+                        .Append("discard");
+
+        Array.ForEach(
+            args.Skip(1).ToArray(),
+            newArgs.Append
+            );
+
+        return newArgs;
+    };
+
+    GitReleaseManagerCreate(
+        data.GitHubToken,
+        data.GitHubOwner,
+        data.GitHubRepository,
+        settings);
+});
+
+Task("Open-Milestone-With-Username-Password")
+    .Does<BuildData>((data) =>
+{
+    var settings = new GitReleaseManagerCloseMilestoneSettings();
+
+    // TODO: This can be replaced when a open alias is added to Cake
+    settings.ArgumentCustomization = args => {
+        var newArgs = new ProcessArgumentBuilder()
+                        .Append("open");
+
+        Array.ForEach(
+            args.Skip(1).ToArray(),
+            newArgs.Append
+            );
+
+        return newArgs;
+    };
+
+    GitReleaseManagerClose(
+        data.GitHubUsername,
+        data.GitHubPassword,
+        data.GitHubOwner,
+        data.GitHubRepository,
+        data.GrmMilestone,
+        settings);
+});
+
+Task("Open-Milestone-With-Token")
+    .Does<BuildData>((data) =>
+{
+    var settings = new GitReleaseManagerCloseMilestoneSettings();
+
+    // TODO: This can be replaced when a open alias is added to Cake
+    settings.ArgumentCustomization = args => {
+        var newArgs = new ProcessArgumentBuilder()
+                        .Append("open");
+
+        Array.ForEach(
+            args.Skip(1).ToArray(),
+            newArgs.Append
+            );
+
+        return newArgs;
+    };
+
+    GitReleaseManagerClose(
+        data.GitHubToken,
+        data.GitHubOwner,
+        data.GitHubRepository,
+        data.GrmMilestone,
+        settings);
+});
+
+Task("Run-All-Tests")
+    .IsDependentOn("Create-Release-With-Username-Password")
+    .IsDependentOn("Add-Asset-To-Release-With-Username-Password")
+    .IsDependentOn("Export-Release-With-Username-Password")
+    .IsDependentOn("Close-Milestone-With-Username-Password")
+    .IsDependentOn("Discard-Release-With-Username-Password")
+    .IsDependentOn("Open-Milestone-With-Username-Password")
+    .IsDependentOn("Create-Release-With-Token")
+    .IsDependentOn("Add-Asset-To-Release-With-Token")
+    .IsDependentOn("Export-Release-With-Token")
+    .IsDependentOn("Close-Milestone-With-Token")
+    .IsDependentOn("Discard-Release-With-Token")
+    .IsDependentOn("Open-Milestone-With-Token");
+
+RunTarget(target);
+
+// Things that still need to be tested further
+// - Exporting with configuration file for footer, replacements, etc
+// - Creating with configuration file for including hashes, etc.
+
+// Aliases which are not currently tested
+// - GitReleaseManagerLabel
+// - GitReleaseManagerPublish

--- a/tests/integration/utilities.cake
+++ b/tests/integration/utilities.cake
@@ -1,0 +1,12 @@
+public bool FileHashEquals(FilePath y, FilePath x)
+{
+    using (var sha512 = System.Security.Cryptography.SHA512.Create())
+    using (System.IO.Stream
+        yStream = System.IO.File.OpenRead(y.FullPath),
+        xStream = System.IO.File.OpenRead(x.FullPath))
+    {
+        var yHash = sha512.ComputeHash(yStream);
+        var xHash = sha512.ComputeHash(xStream);
+        return Enumerable.SequenceEqual(yHash, xHash);
+    }
+}

--- a/tests/integration/xunit.cake
+++ b/tests/integration/xunit.cake
@@ -1,0 +1,24 @@
+#addin "nuget:?package=xunit.assert&version=2.4.1"
+
+using Xunit;
+
+public class Record
+{
+    public static Exception Exception(Action action)
+    {
+        if (action == null)
+        {
+            throw new ArgumentNullException("action");
+        }
+
+        try
+        {
+            action();
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
+    }
+}


### PR DESCRIPTION
## Description

Cake.Recipe has the ability to run an additional Cake script to exercise specific functionality, in order to verify that things are working as expected.  This PR adds this for the various GRM Cake aliases.

## Related Issue

Fixes #140 

## Motivation and Context

Add integration tests will allow us to know that we haven't inadvertently broken something when adding new functionality. 

## How Has This Been Tested?

Tests have been ran against FakeRepository

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
