### PR TITLE
(GH-171) Change target framework for unit tests to .NET Core 2.2

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
     <PropertyGroup>
         <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\GitReleaseManager.ruleset</CodeAnalysisRuleSet>
+        <DebugType>pdbonly</DebugType>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Source/GitReleaseManager.IntegrationTests/GitReleaseManager.IntegrationTests.csproj
+++ b/Source/GitReleaseManager.IntegrationTests/GitReleaseManager.IntegrationTests.csproj
@@ -4,7 +4,6 @@
         <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
         <Title>GitReleaseManager.IntegrationTests</Title>
         <Description>Integration Test Project for GitReleaseManager</Description>
-        <DebugType>full</DebugType>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <NoWarn>CA1707</NoWarn>
     </PropertyGroup>

--- a/Source/GitReleaseManager.IntegrationTests/GitReleaseManager.IntegrationTests.csproj
+++ b/Source/GitReleaseManager.IntegrationTests/GitReleaseManager.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <LangVersion>8.0</LangVersion>
-        <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
+        <TargetFrameworks>net472;netcoreapp2.2</TargetFrameworks>
         <Title>GitReleaseManager.IntegrationTests</Title>
         <Description>Integration Test Project for GitReleaseManager</Description>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/Source/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
+++ b/Source/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <LangVersion>8.0</LangVersion>
-        <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
+        <TargetFrameworks>net472;netcoreapp2.2</TargetFrameworks>
         <Title>GitReleaseManager.Tests</Title>
         <Description>Test Project for GitReleaseManager</Description>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/Source/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
+++ b/Source/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
@@ -4,13 +4,8 @@
         <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
         <Title>GitReleaseManager.Tests</Title>
         <Description>Test Project for GitReleaseManager</Description>
-        <DebugType>full</DebugType>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <NoWarn>CA1707</NoWarn>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-        <Optimize>false</Optimize>
-        <DebugSymbols>true</DebugSymbols>
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="..\SolutionInfo.cs" Link="SolutionInfo.cs" />

--- a/Source/GitReleaseManager/GitReleaseManager.Core.csproj
+++ b/Source/GitReleaseManager/GitReleaseManager.Core.csproj
@@ -5,7 +5,6 @@
         <Title>GitReleaseManager.Core</Title>
         <Description>Create release notes in markdown given a milestone</Description>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-        <DebugType>full</DebugType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes the unit tests libraries to target .NET Core 2.2 instead of 3.0 to fix the message about not being able to generate coverage reports for the .NET Core framework.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #171 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Coverage reports should always be generated.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally, and through appveyor (custom instance)

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
