### PR TITLE
(GH-175) Remove the last couple of .Result calls

### DIFF
--- a/Source/GitReleaseManager.Tests/FakeGitHubClient.cs
+++ b/Source/GitReleaseManager.Tests/FakeGitHubClient.cs
@@ -55,9 +55,9 @@ namespace GitReleaseManager.Tests
             return Task.FromResult(Release);
         }
 
-        public ReadOnlyCollection<Milestone> GetReadOnlyMilestones(string user, string repository)
+        public Task<ReadOnlyCollection<Milestone>> GetReadOnlyMilestonesAsync(string user, string repository)
         {
-            return new ReadOnlyCollection<Milestone>(Milestones);
+            return Task.FromResult(new ReadOnlyCollection<Milestone>(Milestones));
         }
 
         public string GetCommitsLink(string user, string repository, Milestone milestone, Milestone previousMilestone)

--- a/Source/GitReleaseManager/GitHubProvider.cs
+++ b/Source/GitReleaseManager/GitHubProvider.cs
@@ -83,24 +83,24 @@ namespace GitReleaseManager.Core
             return _mapper.Map<Release>(await GetReleaseFromTagNameAsync(user, repository, tagName).ConfigureAwait(false));
         }
 
-        public ReadOnlyCollection<Milestone> GetReadOnlyMilestones(string user, string repository)
+        public async Task<ReadOnlyCollection<Milestone>> GetReadOnlyMilestonesAsync(string user, string repository)
         {
             var milestonesClient = _gitHubClient.Issue.Milestone;
-            var closed = milestonesClient.GetAllForRepository(
+            var closed = await milestonesClient.GetAllForRepository(
                 user,
                 repository,
                 new MilestoneRequest
                 {
                     State = ItemStateFilter.Closed,
-                }).Result;
+                }).ConfigureAwait(false);
 
-            var open = milestonesClient.GetAllForRepository(
+            var open = await milestonesClient.GetAllForRepository(
                 user,
                 repository,
                 new MilestoneRequest
                 {
                     State = ItemStateFilter.Open,
-                }).Result;
+                }).ConfigureAwait(false);
 
             return new ReadOnlyCollection<Milestone>(_mapper.Map<List<Milestone>>(closed.Concat(open).ToList()));
         }

--- a/Source/GitReleaseManager/IVcsProvider.cs
+++ b/Source/GitReleaseManager/IVcsProvider.cs
@@ -23,7 +23,7 @@ namespace GitReleaseManager.Core
 
         Task<Release> GetSpecificRelease(string tagName, string user, string repository);
 
-        ReadOnlyCollection<Milestone> GetReadOnlyMilestones(string user, string repository);
+        Task<ReadOnlyCollection<Milestone>> GetReadOnlyMilestonesAsync(string user, string repository);
 
         Task<Release> CreateReleaseFromMilestone(string owner, string repository, string milestone, string releaseName, string targetCommitish, IList<string> assets, bool prerelease);
 

--- a/Source/GitReleaseManager/ReleaseNotesBuilder.cs
+++ b/Source/GitReleaseManager/ReleaseNotesBuilder.cs
@@ -38,7 +38,7 @@ namespace GitReleaseManager.Core
 
         public async Task<string> BuildReleaseNotes()
         {
-            LoadMilestones();
+            await LoadMilestones();
             GetTargetMilestone();
 
             var issues = await GetIssues(_targetMilestone).ConfigureAwait(false);
@@ -173,9 +173,9 @@ namespace GitReleaseManager.Core
             stringBuilder.AppendLine();
         }
 
-        private void LoadMilestones()
+        private async Task LoadMilestones()
         {
-            _milestones = _vcsProvider.GetReadOnlyMilestones(_user, _repository);
+            _milestones = await _vcsProvider.GetReadOnlyMilestonesAsync(_user, _repository).ConfigureAwait(false);
         }
 
         private async Task<List<Issue>> GetIssues(Milestone milestone)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix calls to `.Result` and use await or pass along a task

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #175 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran unit tests

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
