### PR TITLE
(GH-177) Add open command

### DIFF
--- a/Source/GitReleaseManager.Cli/Options/OpenSubOptions.cs
+++ b/Source/GitReleaseManager.Cli/Options/OpenSubOptions.cs
@@ -1,0 +1,17 @@
+//-----------------------------------------------------------------------
+// <copyright file="OpenSubOptions.cs" company="GitTools Contributors">
+//     Copyright (c) 2015 - Present - GitTools Contributors
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace GitReleaseManager.Cli.Options
+{
+    using CommandLine;
+
+    [Verb("open", HelpText = "Opens the milestone.")]
+    public class OpenSubOptions : BaseVcsOptions
+    {
+        [Option('m', "milestone", HelpText = "The milestone to use.", Required = true)]
+        public string Milestone { get; set; }
+    }
+}

--- a/Source/GitReleaseManager.Cli/Program.cs
+++ b/Source/GitReleaseManager.Cli/Program.cs
@@ -41,7 +41,7 @@ namespace GitReleaseManager.Cli
 
             _mapper = AutoMapperConfiguration.Configure();
 
-            return Parser.Default.ParseArguments<CreateSubOptions, DiscardSubOptions, AddAssetSubOptions, CloseSubOptions, PublishSubOptions, ExportSubOptions, InitSubOptions, ShowConfigSubOptions, LabelSubOptions>(args)
+            return Parser.Default.ParseArguments<CreateSubOptions, DiscardSubOptions, AddAssetSubOptions, CloseSubOptions, PublishSubOptions, ExportSubOptions, InitSubOptions, ShowConfigSubOptions, LabelSubOptions, OpenSubOptions>(args)
                 .WithParsed<BaseSubOptions>(CreateFiglet)
                 .MapResult(
                 (CreateSubOptions opts) => CreateReleaseAsync(opts),
@@ -53,6 +53,7 @@ namespace GitReleaseManager.Cli
                 (InitSubOptions opts) => CreateSampleConfigFileAsync(opts),
                 (ShowConfigSubOptions opts) => ShowConfigAsync(opts),
                 (LabelSubOptions opts) => CreateLabelsAsync(opts),
+                (OpenSubOptions opts) => OpenMilestoneAsync(opts),
                 errs => Task.FromResult(1));
         }
 
@@ -177,6 +178,26 @@ namespace GitReleaseManager.Cli
                 _vcsProvider = GetVcsProvider(subOptions);
 
                 await _vcsProvider.CloseMilestone(subOptions.RepositoryOwner, subOptions.RepositoryName, subOptions.Milestone).ConfigureAwait(false);
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+
+                return 1;
+            }
+        }
+
+        private static async Task<int> OpenMilestoneAsync(OpenSubOptions subOptions)
+        {
+            try
+            {
+                ConfigureLogging(subOptions.LogFilePath);
+
+                _vcsProvider = GetVcsProvider(subOptions);
+
+                await _vcsProvider.OpenMilestone(subOptions.RepositoryOwner, subOptions.RepositoryName, subOptions.Milestone).ConfigureAwait(false);
 
                 return 0;
             }

--- a/Source/GitReleaseManager.Tests/FakeGitHubClient.cs
+++ b/Source/GitReleaseManager.Tests/FakeGitHubClient.cs
@@ -105,6 +105,11 @@ namespace GitReleaseManager.Tests
             throw new System.NotImplementedException();
         }
 
+        public Task OpenMilestone(string owner, string repository, string milestoneTitle)
+        {
+            throw new System.NotImplementedException();
+        }
+
         public Task PublishRelease(string owner, string repository, string tagName)
         {
             throw new System.NotImplementedException();

--- a/Source/GitReleaseManager/GitHubProvider.cs
+++ b/Source/GitReleaseManager/GitHubProvider.cs
@@ -294,6 +294,20 @@ namespace GitReleaseManager.Core
             }
         }
 
+        public async Task OpenMilestone(string owner, string repository, string milestoneTitle)
+        {
+            var milestoneClient = _gitHubClient.Issue.Milestone;
+            var closedMilestones = await milestoneClient.GetAllForRepository(owner, repository, new MilestoneRequest { State = ItemStateFilter.Closed }).ConfigureAwait(false);
+            var milestone = closedMilestones.FirstOrDefault(m => m.Title == milestoneTitle);
+
+            if (milestone == null)
+            {
+                return;
+            }
+
+            await milestoneClient.Update(owner, repository, milestone.Number, new MilestoneUpdate { State = ItemState.Open }).ConfigureAwait(false);
+        }
+
         public async Task PublishRelease(string owner, string repository, string tagName)
         {
             var release = await GetReleaseFromTagNameAsync(owner, repository, tagName).ConfigureAwait(false);

--- a/Source/GitReleaseManager/IVcsProvider.cs
+++ b/Source/GitReleaseManager/IVcsProvider.cs
@@ -37,6 +37,8 @@ namespace GitReleaseManager.Core
 
         Task CloseMilestone(string owner, string repository, string milestoneTitle);
 
+        Task OpenMilestone(string owner, string repository, string milestoneTitle);
+
         Task PublishRelease(string owner, string repository, string tagName);
 
         Task CreateLabels(string owner, string repository);


### PR DESCRIPTION
## Description
To allow the re-opening of a milestone, that might have been closed as
part of an aborted release.  This will help with the exercising of the
integration tests for GitReleaseManager.

## Related Issue

Fixes #177 

## Motivation and Context

Adding this command allows for reverting an action that can be done by GRM.  In the same way that we can discard a created release, we can now re-open a closed milestone.

## How Has This Been Tested?

Tested on Friday Lunch Time Stream, using the FakeRepository on the GitTools Organisation.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
