### PR TITLE
(GH-108) Raise exception when asset doesn't exist

### DIFF
--- a/Source/GitReleaseManager/GitHubProvider.cs
+++ b/Source/GitReleaseManager/GitHubProvider.cs
@@ -211,8 +211,9 @@ namespace GitReleaseManager.Core
                 {
                     if (!File.Exists(asset))
                     {
-                        Logger.WriteWarning(string.Format("Requested asset to be uploaded doesn't exist: {0}", asset));
-                        continue;
+                        var logMessage = string.Format("Requested asset to be uploaded doesn't exist: {0}", asset);
+                        Logger.WriteError(logMessage);
+                        throw new Exception(logMessage);
                     }
 
                     var assetFileName = Path.GetFileName(asset);


### PR DESCRIPTION
## Description
Currently GRM will write a warning to a log file when an asset isn't
there, but in this scenario, we feel it would be better to raise an
exception.

## Related Issue
Fixes #108 

## Motivation and Context

If the file doesn't exist, the user should be informed.  Otherwise, information from the release could get forgotten about.

## How Has This Been Tested?

No, not tested, but expected to work without it.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
