### PR TITLE
(GH-72) Don't create release when not required

### DIFF
--- a/Source/GitReleaseManager.Tests/ReleaseNotesBuilderTests.cs
+++ b/Source/GitReleaseManager.Tests/ReleaseNotesBuilderTests.cs
@@ -18,10 +18,20 @@ namespace GitReleaseManager.Tests
     [TestFixture]
     public class ReleaseNotesBuilderTests
     {
+        public TestContext TestContext { get; set; }
+
+        [OneTimeSetUp]
+        public void Configure()
+        {
+            Logger.WriteError = s => TestContext.WriteLine($"Error: {s}");
+            Logger.WriteInfo = s => TestContext.WriteLine($"Info: {s}");
+            Logger.WriteWarning = s => TestContext.WriteLine($"Warning: {s}");
+        }
+
         [Test]
         public void NoCommitsNoIssues()
         {
-            AcceptTest(0);
+            Assert.Throws<AggregateException>(() => AcceptTest(0));
         }
 
         [Test]
@@ -33,7 +43,7 @@ namespace GitReleaseManager.Tests
         [Test]
         public void SomeCommitsNoIssues()
         {
-            AcceptTest(5);
+            Assert.Throws<AggregateException>(() => AcceptTest(5));
         }
 
         [Test]
@@ -45,7 +55,7 @@ namespace GitReleaseManager.Tests
         [Test]
         public void SingularCommitsNoIssues()
         {
-            AcceptTest(1);
+            Assert.Throws<AggregateException>(() => AcceptTest(1));
         }
 
         [Test]


### PR DESCRIPTION
## Description
If there are no closed issues assigned to a milestone, or if the issues
assigned to the milestone all have excluded labels, than a release
shouldn't get created.  Instead, an exception should be thrown.

## Related Issue
Fixes #72 

## Motivation and Context
Doesn't make sense to create a release when there are no valid issues assigned to the milestone.

## How Has This Been Tested?

Tested during stream using FakeRepository.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
