### PR TITLE
(GH-170) Add warning for not using yaml config

### DIFF
--- a/Source/GitReleaseManager/Configuration/ConfigurationProvider.cs
+++ b/Source/GitReleaseManager/Configuration/ConfigurationProvider.cs
@@ -44,8 +44,6 @@ namespace GitReleaseManager.Core.Configuration
 
             _logger.Warning("Yaml not found, that's ok! Learn more at {Url}", "https://gittools.github.io/GitReleaseManager/docs/yaml");
 
-            _logger.Verbose("No configuration file was found. Loading default configuration.");
-
             return new Config();
         }
 

--- a/Source/GitReleaseManager/Configuration/ConfigurationProvider.cs
+++ b/Source/GitReleaseManager/Configuration/ConfigurationProvider.cs
@@ -42,6 +42,8 @@ namespace GitReleaseManager.Core.Configuration
                 }
             }
 
+            _logger.Warning("Yaml not found, that's ok! Learn more at {Url}", "https://gittools.github.io/GitReleaseManager/docs/yaml");
+
             _logger.Verbose("No configuration file was found. Loading default configuration.");
 
             return new Config();

--- a/docs/input/docs/configuration/default-configuration.md
+++ b/docs/input/docs/configuration/default-configuration.md
@@ -1,6 +1,7 @@
 ---
 Order: 10
 Title: Default Configuration
+RedirectFrom: docs/yaml/index.html
 ---
 
 GitReleaseManager configuration can be controlled using a GitReleaseManager.yaml


### PR DESCRIPTION
## Description

To prevent any confusion about whether or not Yaml config file is being used
or not, add a warning when it isn't being used.

## Related Issue

Fixes #170 

## Motivation and Context

In some circumstances, GRM can be ran from different directories, and this makes
it clear whether or not the YAML file is being used or not.

## How Has This Been Tested?

Not required.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
