### PR TITLE
(GH-158) Deprecate the use of authentication with username+password

### DIFF
--- a/Source/GitReleaseManager.Cli/Options/BaseVcsSubOptions.cs
+++ b/Source/GitReleaseManager.Cli/Options/BaseVcsSubOptions.cs
@@ -5,16 +5,21 @@
 
 namespace GitReleaseManager.Cli.Options
 {
+    using System;
     using CommandLine;
     using Destructurama.Attributed;
 
     public abstract class BaseVcsOptions : BaseSubOptions
     {
-        [Option('u', "username", HelpText = "The username to access Version Control System with.", Required = true, SetName = "Basic Auth")]
+        internal const string OBSOLETE_MESSAGE = "Authentication using username and password have been deprecated, and will be removed in a future release. Please use --token instead!";
+
+        [Obsolete(OBSOLETE_MESSAGE)]
+        [Option('u', "username", HelpText = "(DEPRECATED) The username to access Version Control System with.", Required = true, SetName = "Basic Auth")]
         public string UserName { get; set; }
 
+        [Obsolete(OBSOLETE_MESSAGE)]
         [LogMasked(Text = "[REDACTED]")]
-        [Option('p', "password", HelpText = "The password to access Version Control System with.", Required = true, SetName = "Basic Auth")]
+        [Option('p', "password", HelpText = "(DEPRECATED) The password to access Version Control System with.", Required = true, SetName = "Basic Auth")]
         public string Password { get; set; }
 
         [LogMasked(Text = "[REDACTED]")]

--- a/Source/GitReleaseManager.Cli/Program.cs
+++ b/Source/GitReleaseManager.Cli/Program.cs
@@ -42,6 +42,7 @@ namespace GitReleaseManager.Cli
                     .WithParsed<BaseSubOptions>(LogConfiguration.ConfigureLogging)
                     .WithParsed<BaseSubOptions>(CreateFiglet)
                     .WithParsed<BaseSubOptions>(LogOptions)
+                    .WithParsed<BaseVcsOptions>(ReportUsernamePasswordDeprecation)
                     .MapResult(
                     (CreateSubOptions opts) => CreateReleaseAsync(opts),
                     (DiscardSubOptions opts) => DiscardReleaseAsync(opts),
@@ -73,6 +74,14 @@ namespace GitReleaseManager.Cli
             finally
             {
                 Log.CloseAndFlush();
+            }
+        }
+
+        private static void ReportUsernamePasswordDeprecation(BaseVcsOptions options)
+        {
+            if (!string.IsNullOrEmpty(options.UserName) || !string.IsNullOrEmpty(options.Password))
+            {
+                Log.Warning(BaseVcsOptions.OBSOLETE_MESSAGE);
             }
         }
 

--- a/Source/GitReleaseManager/GitHubProvider.cs
+++ b/Source/GitReleaseManager/GitHubProvider.cs
@@ -33,11 +33,19 @@ namespace GitReleaseManager.Core
         private readonly IMapper _mapper;
         private GitHubClient _gitHubClient;
 
+        [Obsolete("Use overload with token only instead")]
         public GitHubProvider(IMapper mapper, Config configuration, string userName, string password, string token)
         {
             _mapper = mapper;
             _configuration = configuration;
             CreateClient(userName, password, token);
+        }
+
+        public GitHubProvider(IMapper mapper, Config configuration, string token)
+        {
+            _mapper = mapper;
+            _configuration = configuration;
+            CreateClient(token);
         }
 
         public Task<int> GetNumberOfCommitsBetween(Milestone previousMilestone, Milestone currentMilestone, string user, string repository)
@@ -95,12 +103,20 @@ namespace GitReleaseManager.Core
             return new ReadOnlyCollection<Milestone>(_mapper.Map<List<Milestone>>(closed.Concat(open).ToList()));
         }
 
+        [Obsolete("Use overload with token only instead")]
         public void CreateClient(string userName, string password, string token)
         {
             var credentials = string.IsNullOrWhiteSpace(token)
                 ? new Credentials(userName, password)
                 : new Credentials(token);
 
+            var github = new GitHubClient(new ProductHeaderValue("GitReleaseManager")) { Credentials = credentials };
+            _gitHubClient = github;
+        }
+
+        public void CreateClient(string token)
+        {
+            var credentials = new Credentials(token);
             var github = new GitHubClient(new ProductHeaderValue("GitReleaseManager")) { Credentials = credentials };
             _gitHubClient = github;
         }

--- a/docs/input/docs/commands/_auth-notes.md
+++ b/docs/input/docs/commands/_auth-notes.md
@@ -1,0 +1,5 @@
+For Authentication it is recommended to use the token parameter.
+Authentication with a Username and Password have been deprecated, and
+will be removed in a future release of GitReleaseManager.
+This authentication method have also been deprecated officially at
+GitHub.com

--- a/docs/input/docs/commands/_deprecated-args.md
+++ b/docs/input/docs/commands/_deprecated-args.md
@@ -1,0 +1,9 @@
+## Deprecated Parameters
+
+The following parameters have been deprecated and should not be used in new
+code. This will be removed in a future release.
+
+- `-u, --username`: The username to access Version Control System with.
+  This can't be used when using the token parameter.
+- `-p, --password`: The password to access Version Control System with.
+  This can't be used when using the token parameter.

--- a/docs/input/docs/commands/add-assets.md
+++ b/docs/input/docs/commands/add-assets.md
@@ -8,10 +8,6 @@ additional assets to the release using the addasset command.
 
 ## **Required Parameters**
 
-- `-u, --username`: The username to access GitHub with. This can't be used when
-    using the token parameter.
-- `-p, --password`: The password to access GitHub with. This can't be used when
-    using the token parameter.
 - `--token`: The access token to access GitHub with. This can't be used when
     using the username and password parameters.
 - `-o, --owner`: The owner of the repository.
@@ -28,16 +24,18 @@ additional assets to the release using the addasset command.
 - `-l, -logFilePath`: Path to where log file should be created. Defaults to
     logging to console.
 
+<?! Include "_deprecated-args.md /?>
+
 ## **Notes**
 
-For Authentication use either username and password, or token parameter
+<?! Include "_auth-notes.md" /?>
 
 ## **Examples**
 
 ```bash
-gitreleasemanager.exe addasset -t 0.1.0 -u bob -p password -o repoOwner -r repo -a c:\buildartifacts\setup.exe,c:\buildartifacts\setup.nupkg
-
-gitreleasemanager.exe create --tagName 0.1.0 --username bob --password password --owner repoOwner --repository repo --assets c:\buildartifacts\setup.exe,c:\buildartifacts\setup.nupkg
+gitreleasemanager.exe addasset -t 0.1.0 -u bob --token fsdfsf67657sdf5s7d5f -r repo -a c:\buildartifacts\setup.exe,c:\buildartifacts\setup.nupkg
 
 gitreleasemanager.exe create --tagName 0.1.0 --token fsdfsf67657sdf5s7d5f --owner repoOwner --repository repo --assets c:\buildartifacts\setup.exe,c:\buildartifacts\setup.nupkg
+
+gitreleasemanager.exe create --tagName 0.1.0 --username bob --password password --owner repoOwner --repository repo --assets c:\buildartifacts\setup.exe,c:\buildartifacts\setup.nupkg
 ```

--- a/docs/input/docs/commands/close.md
+++ b/docs/input/docs/commands/close.md
@@ -9,10 +9,6 @@ milestone.
 
 ## **Required Parameters**
 
-- `-u, --username`: The username to access GitHub with. This can't be used when
-    using the token parameter.
-- `-p, --password`: The password to access GitHub with. This can't be used when
-    using the token parameter.
 - `--token`: The access token to access GitHub with. This can't be used when
     using the username and password parameters.
 - `-o, --owner`: The owner of the repository.
@@ -26,16 +22,18 @@ milestone.
 - `-l, --logFilePath`: Path to where log file should be created. Defaults to
     logging to console.
 
+<?! Include "_deprecated-args.md /?>
+
 ## **Notes**
 
-For Authentication use either username and password, or token parameter
+<?! Include "_auth-notes.md" /?>
 
 ## **Examples**
 
 ```bash
-gitreleasemanager.exe close -m 0.1.0 -u bob -p password -o repoOwner -r repo
-
-gitreleasemanager.exe close --milestone 0.1.0 --username bob --password password --owner repoOwner --repository repo
+gitreleasemanager.exe close -m 0.1.0 --token fsdfsf67657sdf5s7d5f -o repoOwner -r repo
 
 gitreleasemanager.exe close --milestone 0.1.0 --token fsdfsf67657sdf5s7d5f --owner repoOwner --repository repo
+
+gitreleasemanager.exe close --milestone 0.1.0 --username bob --password password --owner repoOwner --repository repo
 ```

--- a/docs/input/docs/commands/create.md
+++ b/docs/input/docs/commands/create.md
@@ -13,10 +13,6 @@ to include in the Release.
 
 ## **Required Parameters**
 
-- `-u, --username`: The username to access GitHub with. This can't be used when
-    using the token parameter.
-- `-p, --password`: The password to access GitHub with. This can't be used when
-    using the token parameter.
 - `--token`: The access token to access GitHub with. This can't be used when
     using the username and password parameters.
 - `-o, --owner`: The owner of the repository.
@@ -39,9 +35,11 @@ to include in the Release.
 - `-l, --logFilePath`: Path to where log file should be created. Defaults to
     logging to console.
 
+<?! Include "_deprecated-args.md /?>
+
 ## **Notes**
 
-For Authentication use either username and password, or token parameter
+<?! Include "_auth-notes.md" /?>
 
 ## **Examples**
 
@@ -49,19 +47,19 @@ Use GitReleaseManager to create a Release, generating the release notes based on
 Milestone:
 
 ```bash
-gitreleasemanager.exe create -m 0.1.0 -u bob -p password -o repoOwner -r repo
-
-gitreleasemanager.exe create --milestone 0.1.0 --username bob --password password --owner repoOwner --repository repo
+gitreleasemanager.exe create -m 0.1.0 --token fsdfsf67657sdf5s7d5f -o repoOwner -r repo
 
 gitreleasemanager.exe create --milestone 0.1.0 --token fsdfsf67657sdf5s7d5f --owner repoOwner --repository repo
+
+gitreleasemanager.exe create --milestone 0.1.0 --username bob --password password --owner repoOwner --repository repo
 ```
 
 Use GitReleaseManager to create a Release, taking the release notes as an input parameter:
 
 ```bash
-gitreleasemanager.exe create -i c:\temp\releasenotes.md -n 0.1.0 -u bob -p password -o repoOwner -r repo
-
-gitreleasemanager.exe create --inputFilePath c:\temp\releasenotes.md --name 0.1.0 --username bob --password password --owner repoOwner --repository repo
+gitreleasemanager.exe create -i c:\temp\releasenotes.md -n 0.1.0 --token fsdfsf67657sdf5s7d5f -o repoOwner -r repo
 
 gitreleasemanager.exe create --inputFilePath c:\temp\releasenotes.md --name 0.1.0 --token fsdfsf67657sdf5s7d5f --owner repoOwner --repository repo
+
+gitreleasemanager.exe create --inputFilePath c:\temp\releasenotes.md --name 0.1.0 --username bob --password password --owner repoOwner --repository repo
 ```

--- a/docs/input/docs/commands/discard.md
+++ b/docs/input/docs/commands/discard.md
@@ -15,10 +15,6 @@ delete a published release.
 
 ## **Required Parameters**
 
-- `-u, --username`: The username to access GitHub with. This can't be used when
-    using the token parameter.
-- `-p, --password`: The password to access GitHub with. This can't be used when
-    using the token parameter.
 - `--token`: The access token to access GitHub with. This can't be used when
     using the username and password parameters.
 - `-o, --owner`: The owner of the repository.
@@ -33,16 +29,18 @@ delete a published release.
 - `-l, -logFilePath`: Path to where log file should be created. Defaults to
     logging to console.
 
+<?! Include "_deprecated-args.md /?>
+
 ## **Notes**
 
-For Authentication use either username and password, or token parameter
+<?! Include "_auth-notes.md" /?>
 
 ## **Examples**
 
 ```bash
-gitreleasemanager.exe discard -m 0.1.0 -u bob -p password -o repoOwner -r repo
-
-gitreleasemanager.exe discard --milestone 0.1.0 --username bob --password password --owner repoOwner --repository repo
+gitreleasemanager.exe discard -m 0.1.0 --token fsdfsf67657sdf5s7d5f -o repoOwner -r repo
 
 gitreleasemanager.exe discard --milestone 0.1.0 --token fsdfsf67657sdf5s7d5f --owner repoOwner --repository repo
+
+gitreleasemanager.exe discard --milestone 0.1.0 --username bob --password password --owner repoOwner --repository repo
 ```

--- a/docs/input/docs/commands/export.md
+++ b/docs/input/docs/commands/export.md
@@ -13,10 +13,6 @@ using the tagName parameter.
 
 ## **Required Parameters**
 
-- `-u, --username`: The username to access GitHub with. This can't be used when
-    using the token parameter.
-- `-p, --password`: The password to access GitHub with. This can't be used when
-    using the token parameter.
 - `--token`: The access token to access GitHub with. This can't be used when
     using the username and password parameters.
 - `-o, --owner`: The owner of the repository.
@@ -32,18 +28,20 @@ using the tagName parameter.
 - `-l, --logFilePath`: Path to where log file should be created. Defaults to
     logging to console.
 
+<?! Include "_deprecated-args.md /?>
+
 ## **Notes**
 
-For Authentication use either username and password, or token parameter
+<?! Include "_auth-notes.md" /?>
 
 ## **Examples**
 
 Use GitReleaseManager to export all Release Notes:
 
 ```bash
-gitreleasemanager.exe export -u bob -p password -o repoOwner -r repo -f c:\temp\releases.md
-
-gitreleasemanager.exe export --username bob --password password --owner repoOwner --repository repo --fileOutputPath c:\temp\releases.md
+gitreleasemanager.exe export --token fsdfsf67657sdf5s7d5f -o repoOwner -r repo -f c:\temp\releases.md
 
 gitreleasemanager.exe export --token fsdfsf67657sdf5s7d5f --owner repoOwner --repository repo --fileOutputPath c:\temp\releases.md
+
+gitreleasemanager.exe export --username bob --password password --owner repoOwner --repository repo --fileOutputPath c:\temp\releases.md
 ```

--- a/docs/input/docs/commands/label.md
+++ b/docs/input/docs/commands/label.md
@@ -20,10 +20,6 @@ later version.
 
 ## **Required Parameters**
 
-- `-u, --username`: The username to access GitHub with. This can't be used when
-    using the token parameter.
-- `-p, --password`: The password to access GitHub with. This can't be used when
-    using the token parameter.
 - `--token`: The access token to access GitHub with. This can't be used when
     using the username and password parameters.
 - `-o, --owner`: The owner of the repository.
@@ -36,16 +32,18 @@ later version.
 - `-l, -logFilePath`: Path to where log file should be created. Defaults to
     logging to console.
 
+<?! Include "_deprecated-args.md /?>
+
 ## **Notes**
 
-For Authentication use either username and password, or token parameter
+<?! Include "_auth-notes.md" /?>
 
 ## **Examples**
 
 ```bash
-gitreleasemanager.exe label -u bob -p password -o repoOwner -r repo
-
-gitreleasemanager.exe label --username bob --password password --owner repoOwner --repository repo
+gitreleasemanager.exe label --token fsdfsf67657sdf5s7d5f -o repoOwner -r repo
 
 gitreleasemanager.exe label --token fsdfsf67657sdf5s7d5f --owner repoOwner --repository repo
+
+gitreleasemanager.exe label --username bob --password password --owner repoOwner --repository repo
 ```

--- a/docs/input/docs/commands/open.md
+++ b/docs/input/docs/commands/open.md
@@ -18,10 +18,6 @@ will be taken against a milestone that is already open.
 
 ## **Required Parameters**
 
-- `-u, --username`: The username to access GitHub with. This can't be used when
-    using the token parameter.
-- `-p, --password`: The password to access GitHub with. This can't be used when
-    using the token parameter.
 - `--token`: The access token to access GitHub with. This can't be used when
     using the username and password parameters.
 - `-o, --owner`: The owner of the repository.
@@ -35,16 +31,18 @@ will be taken against a milestone that is already open.
 - `-l, --logFilePath`: Path to where log file should be created. Defaults to
     logging to console.
 
+<?! Include "_deprecated-args.md /?>
+
 ## **Notes**
 
-For Authentication use either username and password, or token parameter
+<?! Include "_auth-notes.md" /?>
 
 ## **Examples**
 
 ```bash
-gitreleasemanager.exe open -m 0.1.0 -u bob -p password -o repoOwner -r repo
-
-gitreleasemanager.exe open --milestone 0.1.0 --username bob --password password --owner repoOwner --repository repo
+gitreleasemanager.exe open -m 0.1.0 --token fsdfsf67657sdf5s7d5f -o repoOwner -r repo
 
 gitreleasemanager.exe open --milestone 0.1.0 --token fsdfsf67657sdf5s7d5f --owner repoOwner --repository repo
+
+gitreleasemanager.exe open --milestone 0.1.0 --username bob --password password --owner repoOwner --repository repo
 ```

--- a/docs/input/docs/commands/publish.md
+++ b/docs/input/docs/commands/publish.md
@@ -11,10 +11,6 @@ to actually publish a release.
 
 ## **Required Parameters**
 
-- `-u, --username`: The username to access GitHub with. This can't be used when
-    using the token parameter.
-- `-p, --password`: The password to access GitHub with. This can't be used when
-    using the token parameter.
 - `--token`: The access token to access GitHub with. This can't be used when
     using the username and password parameters.
 - `-o, --owner`: The owner of the repository.
@@ -29,16 +25,18 @@ to actually publish a release.
 - `-l, -logFilePath`: Path to where log file should be created. Defaults to
     logging to console.
 
+<?! Include "_deprecated-args.md /?>
+
 ## **Notes**
 
-For Authentication use either username and password, or token parameter
+<?! Include "_auth-notes.md" /?>
 
 ## **Examples**
 
 ```bash
-gitreleasemanager.exe publish -t 0.1.0 -u bob -p password -o repoOwner -r repo
-
-gitreleasemanager.exe publish --tagName 0.1.0 --username bob --password password --owner repoOwner --repository repo
+gitreleasemanager.exe publish -t 0.1.0 --token fsdfsf67657sdf5s7d5f -o repoOwner -r repo
 
 gitreleasemanager.exe publish --tagName 0.1.0 --token fsdfsf67657sdf5s7d5f --owner repoOwner --repository repo
+
+gitreleasemanager.exe publish --tagName 0.1.0 --username bob --password password --owner repoOwner --repository repo
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request deprecates the use of a username and password for authentication (to be removed in the future).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

fixes #158 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The motivation is two-fold.

1. GitHub have deprecated the authentication with a Username and Password
2. Will make it easier to Migrate to Spectre.Cli when we eventually can remove this authentication method.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested. Logically it should work.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
