### PR TITLE
(GH-195) Fix issue regarding the grabbing of ConsoleWidth during creation of figlet

### DIFF
--- a/Source/GitReleaseManager.Cli/Program.cs
+++ b/Source/GitReleaseManager.Cli/Program.cs
@@ -112,13 +112,36 @@ namespace GitReleaseManager.Cli
                 + "  \\____|_|\\__|_| \\_\\___|_|\\___|\\__,_|___/\\___|_|  |_|\\__,_|_| |_|\\__,_|\\__, |\\___|_|\n"
                 + "                                                                       |___/\n"
                 + "{0,87}\n";
-            if (Console.WindowWidth > 87)
+
+            if (GetConsoleWidth() > 87)
             {
                 Log.Information(longFormat, version);
             }
             else
             {
                 Log.Information(shortFormat, version);
+            }
+        }
+
+        private static int GetConsoleWidth()
+        {
+            try
+            {
+                return Console.WindowWidth;
+            }
+            catch
+            {
+                Log.Verbose("Unable to get the width of the console.");
+            }
+
+            try
+            {
+                return Console.BufferWidth;
+            }
+            catch
+            {
+                Log.Verbose("Unable to get the width of the buffer");
+                return int.MaxValue;
             }
         }
 

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:https://www.myget.org/F/cake-contrib/api/v2?package=Cake.Recipe&version=2.0.0-unstable0157&prerelease
+#load nuget:https://www.myget.org/F/cake-contrib/api/v2?package=Cake.Recipe&version=2.0.0-unstable0023&prerelease
 
 Environment.SetVariableNames(githubUserNameVariable: "GITTOOLS_GITHUB_USERNAME",
                             githubPasswordVariable: "GITTOOLS_GITHUB_PASSWORD");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Basically, changing the grabbing of console to be in a try/catch statement, then if that fails try the BufferWidth, and ultimately fallback to the maximum value of int (most cases, I believe the console width would be long enough in these cases).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #195 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To be able to use GRM without passing in `--no-logo` argument.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unfortunately not tested, as I do not have a context which these cases will fail set up to use this version of GRM correctly.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
