### PR TITLE
(GH-197) Fixed .NET Core global tool not being installed correctly on unix

### DIFF
--- a/Source/GitReleaseManager.Cli/Directory.Build.props
+++ b/Source/GitReleaseManager.Cli/Directory.Build.props
@@ -6,7 +6,7 @@
     <ItemGroup>
         <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-        <PackageReference Include="Serilog.Sinks.Debug" Version="1.0.1" Privateassets="All" />
+        <PackageReference Include="Serilog.Sinks.Debug" Version="1.0.1" PrivateAssets="All" />
         <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     </ItemGroup>
 </Project>

--- a/Source/GitReleaseManager.Cli/GitReleaseManager.Tool.csproj
+++ b/Source/GitReleaseManager.Cli/GitReleaseManager.Tool.csproj
@@ -23,6 +23,7 @@
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/GitTools/GitReleaseManager.git</RepositoryUrl>
+        <PackageVersion Condition="'$(PackageVersion)'!=''">$(PackageVersion.ToLower())</PackageVersion>
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="..\SolutionInfo.cs" Link="SolutionInfo.cs" />


### PR DESCRIPTION
Currently only used for testing. Will be cleaned up and filled out when completed.

This almost seem to happen only on pre-release versions where the package version contains uppercase characters