### PR TITLE
(#99) Add SkipPrereleases option

### DIFF
--- a/src/GitReleaseManager.Core.Tests/Commands/ExportCommandTests.cs
+++ b/src/GitReleaseManager.Core.Tests/Commands/ExportCommandTests.cs
@@ -39,7 +39,7 @@ namespace GitReleaseManager.Core.Tests.Commands
 
             var releaseText = "releaseText";
 
-            _vcsService.ExportReleasesAsync(options.RepositoryOwner, options.RepositoryName, options.TagName)
+            _vcsService.ExportReleasesAsync(options.RepositoryOwner, options.RepositoryName, options.TagName, options.SkipPrereleases)
                 .Returns(releaseText);
 
             var result = await _command.Execute(options).ConfigureAwait(false);
@@ -51,7 +51,7 @@ namespace GitReleaseManager.Core.Tests.Commands
             var exportFileContent = File.ReadAllText(_fileOutputPath);
             exportFileContent.ShouldBe(releaseText);
 
-            await _vcsService.Received(1).ExportReleasesAsync(options.RepositoryOwner, options.RepositoryName, options.TagName).ConfigureAwait(false);
+            await _vcsService.Received(1).ExportReleasesAsync(options.RepositoryOwner, options.RepositoryName, options.TagName, options.SkipPrereleases).ConfigureAwait(false);
             _logger.Received(1).Information(Arg.Any<string>(), options.TagName);
 
             if (exportFileExists)

--- a/src/GitReleaseManager.Core.Tests/Provider/GitHubProviderTests.cs
+++ b/src/GitReleaseManager.Core.Tests/Provider/GitHubProviderTests.cs
@@ -41,6 +41,7 @@ namespace GitReleaseManager.Core.Tests.Provider
         private const int RELEASE_ID = 1;
         private const int ASSET_ID = 1;
         private const string NOT_FOUND_MESSAGE = "NotFound";
+        private const bool SKIP_PRERELEASES = false;
 
         private readonly Release _release = new Release();
         private readonly ReleaseAssetUpload _releaseAssetUpload = new ReleaseAssetUpload();
@@ -667,7 +668,7 @@ namespace GitReleaseManager.Core.Tests.Provider
             _mapper.Map<IEnumerable<Release>>(Arg.Any<object>())
                 .Returns(releases);
 
-            var result = await _gitHubProvider.GetReleasesAsync(OWNER, REPOSITORY).ConfigureAwait(false);
+            var result = await _gitHubProvider.GetReleasesAsync(OWNER, REPOSITORY, SKIP_PRERELEASES).ConfigureAwait(false);
             result.ShouldBeSameAs(releases);
 
             await _gitHubClient.Repository.Release.Received(1).GetAll(OWNER, REPOSITORY, Arg.Any<ApiOptions>()).ConfigureAwait(false);
@@ -680,7 +681,7 @@ namespace GitReleaseManager.Core.Tests.Provider
             _gitHubClient.Repository.Release.GetAll(OWNER, REPOSITORY, Arg.Any<ApiOptions>())
                 .Returns(Task.FromException<IReadOnlyList<Octokit.Release>>(_exception));
 
-            var ex = await Should.ThrowAsync<ApiException>(() => _gitHubProvider.GetReleasesAsync(OWNER, REPOSITORY)).ConfigureAwait(false);
+            var ex = await Should.ThrowAsync<ApiException>(() => _gitHubProvider.GetReleasesAsync(OWNER, REPOSITORY, SKIP_PRERELEASES)).ConfigureAwait(false);
             ex.Message.ShouldBe(_exception.Message);
             ex.InnerException.ShouldBe(_exception);
         }

--- a/src/GitReleaseManager.Core.Tests/VcsServiceTests.cs
+++ b/src/GitReleaseManager.Core.Tests/VcsServiceTests.cs
@@ -31,6 +31,7 @@ namespace GitReleaseManager.Core.Tests
         private const string TAG_NAME = "0.1.0";
         private const string RELEASE_NOTES = "Release Notes";
         private const string ASSET_CONTENT = "Asset Content";
+        private const bool SKIP_PRERELEASES = false;
 
         private const string UNABLE_TO_FOUND_MILESTONE_MESSAGE = "Unable to find a {State} milestone with title '{Title}' on '{Owner}/{Repository}'";
         private const string UNABLE_TO_FOUND_RELEASE_MESSAGE = "Unable to find a release with tag '{TagName}' on '{Owner}/{Repository}'";
@@ -591,17 +592,17 @@ namespace GitReleaseManager.Core.Tests
             var releases = Enumerable.Empty<Release>();
             var releaseNotes = "Release Notes";
 
-            _vcsProvider.GetReleasesAsync(OWNER, REPOSITORY)
+            _vcsProvider.GetReleasesAsync(OWNER, REPOSITORY, SKIP_PRERELEASES)
                 .Returns(Task.FromResult(releases));
 
             _releaseNotesExporter.ExportReleaseNotes(Arg.Any<IEnumerable<Release>>())
                 .Returns(releaseNotes);
 
-            var result = await _vcsService.ExportReleasesAsync(OWNER, REPOSITORY, null).ConfigureAwait(false);
+            var result = await _vcsService.ExportReleasesAsync(OWNER, REPOSITORY, null, SKIP_PRERELEASES).ConfigureAwait(false);
             result.ShouldBeSameAs(releaseNotes);
 
             await _vcsProvider.DidNotReceive().GetReleaseAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()).ConfigureAwait(false);
-            await _vcsProvider.Received(1).GetReleasesAsync(OWNER, REPOSITORY).ConfigureAwait(false);
+            await _vcsProvider.Received(1).GetReleasesAsync(OWNER, REPOSITORY, SKIP_PRERELEASES).ConfigureAwait(false);
             _logger.Received(1).Verbose(Arg.Any<string>(), OWNER, REPOSITORY);
             _releaseNotesExporter.Received(1).ExportReleaseNotes(Arg.Any<IEnumerable<Release>>());
         }
@@ -617,11 +618,11 @@ namespace GitReleaseManager.Core.Tests
             _releaseNotesExporter.ExportReleaseNotes(Arg.Any<IEnumerable<Release>>())
                 .Returns(RELEASE_NOTES);
 
-            var result = await _vcsService.ExportReleasesAsync(OWNER, REPOSITORY, TAG_NAME).ConfigureAwait(false);
+            var result = await _vcsService.ExportReleasesAsync(OWNER, REPOSITORY, TAG_NAME, SKIP_PRERELEASES).ConfigureAwait(false);
             result.ShouldBeSameAs(RELEASE_NOTES);
 
             await _vcsProvider.Received(1).GetReleaseAsync(OWNER, REPOSITORY, TAG_NAME).ConfigureAwait(false);
-            await _vcsProvider.DidNotReceive().GetReleasesAsync(Arg.Any<string>(), Arg.Any<string>()).ConfigureAwait(false);
+            await _vcsProvider.DidNotReceive().GetReleasesAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()).ConfigureAwait(false);
             _logger.Received(1).Verbose(Arg.Any<string>(), OWNER, REPOSITORY, TAG_NAME);
             _releaseNotesExporter.Received(1).ExportReleaseNotes(Arg.Any<IEnumerable<Release>>());
         }
@@ -635,7 +636,7 @@ namespace GitReleaseManager.Core.Tests
             _releaseNotesExporter.ExportReleaseNotes(Arg.Any<IEnumerable<Release>>())
                 .Returns(RELEASE_NOTES);
 
-            var result = await _vcsService.ExportReleasesAsync(OWNER, REPOSITORY, TAG_NAME).ConfigureAwait(false);
+            var result = await _vcsService.ExportReleasesAsync(OWNER, REPOSITORY, TAG_NAME, SKIP_PRERELEASES).ConfigureAwait(false);
             result.ShouldBeSameAs(RELEASE_NOTES);
 
             await _vcsProvider.Received(1).GetReleaseAsync(OWNER, REPOSITORY, TAG_NAME).ConfigureAwait(false);

--- a/src/GitReleaseManager.Core/Commands/ExportCommand.cs
+++ b/src/GitReleaseManager.Core/Commands/ExportCommand.cs
@@ -19,7 +19,7 @@ namespace GitReleaseManager.Core.Commands
         public async Task<int> Execute(ExportSubOptions options)
         {
             _logger.Information("Exporting release {TagName}", options.TagName);
-            var releasesContent = await _vcsService.ExportReleasesAsync(options.RepositoryOwner, options.RepositoryName, options.TagName).ConfigureAwait(false);
+            var releasesContent = await _vcsService.ExportReleasesAsync(options.RepositoryOwner, options.RepositoryName, options.TagName, options.SkipPrereleases).ConfigureAwait(false);
 
             using (var sw = new StreamWriter(File.Open(options.FileOutputPath, FileMode.OpenOrCreate)))
             {

--- a/src/GitReleaseManager.Core/IVcsService.cs
+++ b/src/GitReleaseManager.Core/IVcsService.cs
@@ -14,7 +14,7 @@ namespace GitReleaseManager.Core
 
         Task AddAssetsAsync(string owner, string repository, string tagName, IList<string> assets);
 
-        Task<string> ExportReleasesAsync(string owner, string repository, string tagName);
+        Task<string> ExportReleasesAsync(string owner, string repository, string tagName, bool skipPrereleases);
 
         Task CloseMilestoneAsync(string owner, string repository, string milestoneTitle);
 

--- a/src/GitReleaseManager.Core/Options/ExportSubOptions.cs
+++ b/src/GitReleaseManager.Core/Options/ExportSubOptions.cs
@@ -10,5 +10,8 @@ namespace GitReleaseManager.Core.Options
 
         [Option('t', "tagName", HelpText = "The name of the release (Typically this is the generated SemVer Version Number).", Required = false)]
         public string TagName { get; set; }
+
+        [Option("skipPrereleases", HelpText = "Should pre-release releases be ignored when generating release notes? Defaults to false.", Required = false)]
+        public bool SkipPrereleases { get; set; }
     }
 }

--- a/src/GitReleaseManager.Core/Provider/GitHubProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/GitHubProvider.cs
@@ -260,7 +260,7 @@ namespace GitReleaseManager.Core.Provider
             });
         }
 
-        public Task<IEnumerable<Release>> GetReleasesAsync(string owner, string repository)
+        public Task<IEnumerable<Release>> GetReleasesAsync(string owner, string repository, bool skipPrereleases)
         {
             return ExecuteAsync(async () =>
             {
@@ -273,7 +273,15 @@ namespace GitReleaseManager.Core.Provider
                     var options = GetApiOptions(startPage);
                     results = await _gitHubClient.Repository.Release.GetAll(owner, repository, options).ConfigureAwait(false);
 
-                    releases.AddRange(results);
+                    if (skipPrereleases)
+                    {
+                        releases.AddRange(results.Where(r => !r.Prerelease));
+                    }
+                    else
+                    {
+                        releases.AddRange(results);
+                    }
+
                     startPage++;
                 }
                 while (results.Count == PAGE_SIZE);

--- a/src/GitReleaseManager.Core/Provider/IVcsProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/IVcsProvider.cs
@@ -38,7 +38,7 @@ namespace GitReleaseManager.Core.Provider
 
         Task<Release> GetReleaseAsync(string owner, string repository, string tagName);
 
-        Task<IEnumerable<Release>> GetReleasesAsync(string owner, string repository);
+        Task<IEnumerable<Release>> GetReleasesAsync(string owner, string repository, bool skipPrereleases);
 
         Task PublishReleaseAsync(string owner, string repository, string tagName, int releaseId);
 

--- a/src/GitReleaseManager.Core/VcsService.cs
+++ b/src/GitReleaseManager.Core/VcsService.cs
@@ -204,14 +204,14 @@ namespace GitReleaseManager.Core
             }
         }
 
-        public async Task<string> ExportReleasesAsync(string owner, string repository, string tagName)
+        public async Task<string> ExportReleasesAsync(string owner, string repository, string tagName, bool skipPrereleases)
         {
             var releases = Enumerable.Empty<Release>();
 
             if (string.IsNullOrWhiteSpace(tagName))
             {
                 _logger.Verbose("Finding all releases on '{Owner}/{Repository}'", owner, repository);
-                releases = await _vcsProvider.GetReleasesAsync(owner, repository).ConfigureAwait(false);
+                releases = await _vcsProvider.GetReleasesAsync(owner, repository, skipPrereleases).ConfigureAwait(false);
             }
             else
             {

--- a/src/GitReleaseManager.IntegrationTests/GitHubProviderIntegrationTests.cs
+++ b/src/GitReleaseManager.IntegrationTests/GitHubProviderIntegrationTests.cs
@@ -19,6 +19,7 @@ namespace GitReleaseManager.IntegrationTests
     {
         private const string OWNER = "GitTools";
         private const string REPOSITORY = "GitReleaseManager";
+        private const bool SKIP_PRERELEASES = false;
 
         private GitHubProvider _gitHubProvider;
         private IGitHubClient _gitHubClient;
@@ -87,7 +88,7 @@ namespace GitReleaseManager.IntegrationTests
         [Order(5)]
         public async Task Should_Get_Releases()
         {
-            var result = await _gitHubProvider.GetReleasesAsync(OWNER, REPOSITORY).ConfigureAwait(false);
+            var result = await _gitHubProvider.GetReleasesAsync(OWNER, REPOSITORY, SKIP_PRERELEASES).ConfigureAwait(false);
             result.Count().ShouldBeGreaterThan(0);
 
             var orderedReleases = result.OrderByDescending(r => r.Id).ToList();

--- a/src/GitReleaseManager.Tests/VcsServiceMock.cs
+++ b/src/GitReleaseManager.Tests/VcsServiceMock.cs
@@ -45,7 +45,7 @@ namespace GitReleaseManager.Tests
             throw new System.NotImplementedException();
         }
 
-        public Task<string> ExportReleasesAsync(string owner, string repository, string tagName)
+        public Task<string> ExportReleasesAsync(string owner, string repository, string tagName, bool skipPrereleases)
         {
             throw new System.NotImplementedException();
         }


### PR DESCRIPTION
This will allow the exclusion of pre-releases from the generated
markdown file. By default, all releases will be included.

Fixes #99