### PR TITLE
(#113) Return all issues that have errors

### DIFF
--- a/src/GitReleaseManager.Core/Exceptions/InvalidIssuesException.cs
+++ b/src/GitReleaseManager.Core/Exceptions/InvalidIssuesException.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+namespace GitReleaseManager.Core.Exceptions
+{
+    [Serializable]
+    public class InvalidIssuesException : Exception
+    {
+        public InvalidIssuesException()
+        {
+        }
+
+        public InvalidIssuesException(List<string> errors)
+            : base(string.Join(Environment.NewLine, errors))
+        {
+            Errors = errors;
+        }
+
+        public InvalidIssuesException(List<string> errors, string message)
+            : base(message)
+        {
+            Errors = errors;
+        }
+
+        public InvalidIssuesException(List<string> errors, string message, Exception inner)
+            : base(message, inner)
+        {
+            Errors = errors;
+        }
+
+        public List<string> Errors { get; set; }
+
+        protected InvalidIssuesException(
+            System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context)
+            : base(info, context) { }
+    }
+}

--- a/src/GitReleaseManager.Tests/ReleaseNotesBuilderTests.cs
+++ b/src/GitReleaseManager.Tests/ReleaseNotesBuilderTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using ApprovalTests;
 using GitReleaseManager.Core.Configuration;
+using GitReleaseManager.Core.Exceptions;
 using GitReleaseManager.Core.Helpers;
 using GitReleaseManager.Core.Model;
 using GitReleaseManager.Core.Provider;
@@ -150,14 +151,30 @@ namespace GitReleaseManager.Tests
         public void NoCommitsWrongIssueLabel()
         {
             var exception = Assert.Throws<AggregateException>(() => AcceptTest(0, CreateIssue(1, "Test")));
-            Assert.That(exception.InnerException, Is.Not.Null.And.TypeOf<InvalidOperationException>());
+            Assert.That(exception.InnerException, Is.Not.Null.And.TypeOf<InvalidIssuesException>());
         }
 
         [Test]
         public void SomeCommitsWrongIssueLabel()
         {
             var exception = Assert.Throws<AggregateException>(() => AcceptTest(5, CreateIssue(1, "Test")));
-            Assert.That(exception.InnerException, Is.Not.Null.And.TypeOf<InvalidOperationException>());
+            Assert.That(exception.InnerException, Is.Not.Null.And.TypeOf<InvalidIssuesException>());
+        }
+
+        [Test]
+        public void NoCommitsMultipleWrongIssueLabel()
+        {
+            var exception = Assert.Throws<AggregateException>(() => AcceptTest(0, CreateIssue(1, "Test"), CreateIssue(2, "Test")));
+            Assert.That(exception.InnerException, Is.Not.Null.And.TypeOf<InvalidIssuesException>());
+            Assert.That((exception.InnerException as InvalidIssuesException).Errors.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void SomeCommitsMultipleWrongIssueLabel()
+        {
+            var exception = Assert.Throws<AggregateException>(() => AcceptTest(5, CreateIssue(1, "Test"), CreateIssue(2, "Test"), CreateIssue(3, "Bob")));
+            Assert.That(exception.InnerException, Is.Not.Null.And.TypeOf<InvalidIssuesException>());
+            Assert.That((exception.InnerException as InvalidIssuesException).Errors.Count, Is.EqualTo(3));
         }
 
         [Test]


### PR DESCRIPTION
## Description
When there are issues that contain invalid issues, rather than throw
a single exception for the first problem, throw an exception that
contains information about all the problematic issues.  This saves the
end user from having to run GRM multiple times, fixing one issue at
a time.

## Related Issue
Fixes #113

## Motivation and Context
This makes it much easier for working through problematic issues, and prevents the need to run GRM multiple times.

## How Has This Been Tested?
New unit tests have been added, and existing tests have been exercised and validated.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
