### PR TITLE
(#112) Add new method for creating empty release

### DIFF
--- a/docs/input/docs/commands/create.md
+++ b/docs/input/docs/commands/create.md
@@ -6,10 +6,11 @@ Title: Create
 This is the main command of GitReleaseManager and it is used to create a draft
 set of release notes based on a milestone, which has been set up in GitHub.
 
-There are two modes of operation when creating a Release. GitReleaseManager can
+There are three modes of operation when creating a Release. GitReleaseManager can
 take as an input the name of the milestone to generate the release notes from.
 Or, it can take as an input the name of a file which contains the release notes
 to include in the Release.
+Or, it can create a release that doesn't contain any release notes, i.e. it is empty.
 
 ## **Required Parameters**
 
@@ -35,6 +36,8 @@ to include in the Release.
     logging to console.
 - `-t, --template`: The path to the file to be used as the template for the
     release notes.
+- `--allowEmpty`: Allow the creation of an empty set of release notes. In this
+mode, milestone and input file path will be ignored.
 
 ## **Template**
 
@@ -60,4 +63,10 @@ Use GitReleaseManager to create a Release, taking the release notes as an input 
 gitreleasemanager.exe create -i c:\temp\releasenotes.md -n 0.1.0 --token fsdfsf67657sdf5s7d5f -o repoOwner -r repo
 
 gitreleasemanager.exe create --inputFilePath c:\temp\releasenotes.md --name 0.1.0 --token fsdfsf67657sdf5s7d5f --owner repoOwner --repository repo
+```
+
+Use GitReleaseManager to create an empty release:
+
+```bash
+gitreleasemanager.exe create -n 0.1.0 --token fsdfsf67657sdf5s7d5f -o repoOwner -r repo --allowEmpty
 ```

--- a/src/GitReleaseManager.Core/Commands/CreateCommand.cs
+++ b/src/GitReleaseManager.Core/Commands/CreateCommand.cs
@@ -22,7 +22,12 @@ namespace GitReleaseManager.Core.Commands
 
             Release release;
 
-            if (!string.IsNullOrEmpty(options.Milestone))
+            if (options.AllowEmpty)
+            {
+                _logger.Verbose("The AllowEmpty option has been passed, so an empty release will now be created");
+                release = await _vcsService.CreateEmptyReleaseAsync(options.RepositoryOwner, options.RepositoryName, options.Name, options.TargetCommitish, options.Prerelease).ConfigureAwait(false);
+            }
+            else if (!string.IsNullOrEmpty(options.Milestone))
             {
                 _logger.Verbose("Milestone {Milestone} was specified", options.Milestone);
                 var releaseName = options.Name;

--- a/src/GitReleaseManager.Core/IVcsService.cs
+++ b/src/GitReleaseManager.Core/IVcsService.cs
@@ -6,6 +6,8 @@ namespace GitReleaseManager.Core
 {
     public interface IVcsService
     {
+        Task<Release> CreateEmptyReleaseAsync(string owner, string repository, string name, string targetCommitish, bool prerelease);
+
         Task<Release> CreateReleaseFromMilestoneAsync(string owner, string repository, string milestone, string releaseName, string targetCommitish, IList<string> assets, bool prerelease, string templateFilePath);
 
         Task<Release> CreateReleaseFromInputFileAsync(string owner, string repository, string name, string inputFilePath, string targetCommitish, IList<string> assets, bool prerelease);

--- a/src/GitReleaseManager.Core/Options/CreateSubOptions.cs
+++ b/src/GitReleaseManager.Core/Options/CreateSubOptions.cs
@@ -26,5 +26,8 @@ namespace GitReleaseManager.Core.Options
 
         [Option('e', "pre", Required = false, HelpText = "Creates the release as a pre-release.")]
         public bool Prerelease { get; set; }
+
+        [Option("allowEmpty", Required = false, HelpText = "Allow the creation of an empty set of release notes. In this mode, milestone and input file path will be ignored.")]
+        public bool AllowEmpty { get; set; }
     }
 }

--- a/src/GitReleaseManager.Core/VcsService.cs
+++ b/src/GitReleaseManager.Core/VcsService.cs
@@ -37,6 +37,12 @@ namespace GitReleaseManager.Core
             _configuration = configuration;
         }
 
+        public async Task<Release> CreateEmptyReleaseAsync(string owner, string repository, string name, string targetCommitish, bool prerelease)
+        {
+            var release = await CreateReleaseAsync(owner, repository, name, name, string.Empty, prerelease, targetCommitish, null).ConfigureAwait(false);
+            return release;
+        }
+
         public async Task<Release> CreateReleaseFromMilestoneAsync(string owner, string repository, string milestone, string releaseName, string targetCommitish, IList<string> assets, bool prerelease, string templateFilePath)
         {
             var templatePath = ReleaseTemplates.DEFAULT_NAME;

--- a/src/GitReleaseManager.Tests/VcsServiceMock.cs
+++ b/src/GitReleaseManager.Tests/VcsServiceMock.cs
@@ -25,6 +25,11 @@ namespace GitReleaseManager.Tests
 
         public int NumberOfCommits { get; set; }
 
+        public Task<Release> CreateEmptyReleaseAsync(string owner, string repository, string name, string targetCommitish, bool prerelease)
+        {
+            throw new System.NotImplementedException();
+        }
+
         public Task<Release> CreateReleaseFromMilestoneAsync(string owner, string repository, string milestone, string releaseName, string targetCommitish, IList<string> assets, bool prerelease, string templateFilePath)
         {
             throw new System.NotImplementedException();


### PR DESCRIPTION
## Description
This is similar to the overload for passing in an input file, the
difference being that string.Empty is passed in, rather than reading
the contents of the file, and then creating a release.

## Related Issue

#112

## Motivation and Context
This allows the creation of an empty release, to allow for starting the release process, without having actually done any work.

## How Has This Been Tested?

New unit tests have been added, similar to existing functionality.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
