### PR TITLE
(#379) Validate old config file do not exist

### DIFF
--- a/src/GitReleaseManager.Core/Configuration/ConfigurationProvider.cs
+++ b/src/GitReleaseManager.Core/Configuration/ConfigurationProvider.cs
@@ -64,30 +64,32 @@ namespace GitReleaseManager.Core.Configuration
 
             var defaultConfigFilePath = Path.Combine(targetDirectory, "GitReleaseManager.yml");
 
-            if (!fileSystem.Exists(defaultConfigFilePath))
+            foreach (var possiblePaths in new[] { defaultConfigFilePath, Path.Combine(targetDirectory, "GitReleaseManager.yaml") })
             {
-                _logger.Information("Writing sample file to '{ConfigFilePath}'", defaultConfigFilePath);
-
-                // The following try/finally statements is to ensure that
-                // any stream is not disposed more than once.
-                Stream stream = null;
-                try
+                if (fileSystem.Exists(possiblePaths))
                 {
-                    stream = fileSystem.OpenWrite(defaultConfigFilePath);
-                    using (var writer = new StreamWriter(stream))
-                    {
-                        stream = null;
-                        ConfigSerializer.WriteSample(writer);
-                    }
-                }
-                finally
-                {
-                    stream?.Dispose();
+                    _logger.Error("Cannot write sample, '{File}' already exists", possiblePaths);
+                    return;
                 }
             }
-            else
+
+            _logger.Information("Writing sample file to '{ConfigFilePath}'", defaultConfigFilePath);
+
+            // The following try/finally statements is to ensure that
+            // any stream is not disposed more than once.
+            Stream stream = null;
+            try
             {
-                _logger.Error("Cannot write sample, '{File}' already exists", defaultConfigFilePath);
+                stream = fileSystem.OpenWrite(defaultConfigFilePath);
+                using (var writer = new StreamWriter(stream))
+                {
+                    stream = null;
+                    ConfigSerializer.WriteSample(writer);
+                }
+            }
+            finally
+            {
+                stream?.Dispose();
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The changes in this pull requests adds an additional check to ensure that no new configuration file is created, even in the case that a configuration file with the old legacy name exist.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #379

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A new unit test has been created to test the new check.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
