### PR TITLE
(#399) included GitReleaseManager.exe.config in nuget

### DIFF
--- a/nuspec/nuget/GitReleaseManager.nuspec
+++ b/nuspec/nuget/GitReleaseManager.nuspec
@@ -21,6 +21,7 @@
     </metadata>
     <files>
         <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net472\*.exe" target="tools" />
+        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net472\*.exe.config" target="tools" />
         <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net472\*.xml" target="tools" />
         <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net472\*.dll" target="tools" exclude="**\Serilog.Sinks.Debug.dll" />
         <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net472\*.pdb" target="tools" />


### PR DESCRIPTION
## Description
GitReleaseManager.exe.config contains a AssemblyBinding-redirect
which is needed to use GitReleaseManager.exe.

## Related Issue
fixes #399

## Motivation and Context
#399 

## How Has This Been Tested?
* build and pack the nuget package
* unzip the nupkg
* cd into the tools folder
* call `GitReleaseManager.exe label --token a -o b -r c`
* #399 does no longer occur 

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
