### PR TITLE
Issue 454: Assets on a draft release can be null

### DIFF
--- a/src/GitReleaseManager.Core/VcsService.cs
+++ b/src/GitReleaseManager.Core/VcsService.cs
@@ -101,7 +101,7 @@ namespace GitReleaseManager.Core
                 await _vcsProvider.UpdateReleaseAsync(owner, repository, release).ConfigureAwait(false);
             }
 
-            await AddAssetsAsync(owner, repository, tagName, assets).ConfigureAwait(false);
+            await AddAssetsAsync(owner, repository, tagName, assets, release).ConfigureAwait(false);
 
             return release;
         }
@@ -127,13 +127,15 @@ namespace GitReleaseManager.Core
             }
         }
 
-        public async Task AddAssetsAsync(string owner, string repository, string tagName, IList<string> assets)
+        public async Task AddAssetsAsync(string owner, string repository, string tagName, IList<string> assets) => await AddAssetsAsync(owner, repository, tagName, assets, null);
+
+        private async Task AddAssetsAsync(string owner, string repository, string tagName, IList<string> assets, Release currentRelease)
         {
             if (assets?.Any() == true)
             {
                 try
                 {
-                    var release = await _vcsProvider.GetReleaseAsync(owner, repository, tagName).ConfigureAwait(false);
+                    var release = currentRelease ?? await _vcsProvider.GetReleaseAsync(owner, repository, tagName).ConfigureAwait(false);
 
                     foreach (var asset in assets)
                     {


### PR DESCRIPTION
Address issue #454 

# How to reproduce it

I can reproduce the issue when I execute the command below

```
grm create --milestone 2.0.1 --token [HIDDEN] --owner OWNER --repository [REPOSITORY] --assets "D:/Projects/project/Publish/xxx.2.0.1-beta.64.bin.zip", "D:/Projects/project/Publish/xxx.2.0.1-beta.64.setup.exe"
```

# What is happening? 
The problem is that when I'm getting the release, I'm trying to find a released tagged `2.0.1`. Because there's no release (sic.) with tag `2.0.1`, `NULL` is returned
https://github.com/GitTools/GitReleaseManager/blob/c0d8b8e4dd54e72c22126971b7fc2b44855c8e99/src/GitReleaseManager.Core/VcsService.cs#L136

Later, I'm trying to query the assets on a `NULL` collection of releases => `NullReferenceException`

https://github.com/GitTools/GitReleaseManager/blob/c0d8b8e4dd54e72c22126971b7fc2b44855c8e99/src/GitReleaseManager.Core/VcsService.cs#L147

# Why is it happening?

When creating a release with assets, it first creates the release, and then it uploads the assets. To upload the assets, we need the release, therefore we retrieve the created release.

It seems that when we try to retrieve the freshly created release, it's not yet available and this is the root cause of the `NullReferenceException`

# How to fix it?

Instead of retrieving the release from the wire, we can provide the created release to the method that is in charge of uploading the assets


