### PR TITLE
#492 feat: renaming label Name using RenameFrom in Configuration

### DIFF
--- a/docs/input/docs/commands/label.md
+++ b/docs/input/docs/commands/label.md
@@ -8,14 +8,15 @@ default labels, so that you can have some consistency across your various
 projects.  While GitHub, and other Source Control systems provide a set of
 default labels, they are not always exactly what you want.  This command will
 remove all the current labels configured within a repository, and create a new
-set of them.
+set of them. However, if RenameFrom is specified in the label configuration, the 
+label can be renamed instead of being deleted and recreated.
 
 :::{.alert .alert-info}
 **NOTE:**
 
-The available list of labels that are created is currently hard-coded into
-GitReleaseManager, it is not possible to configure them.  This will come in a
-later version.
+The available list of labels that are created by default is currently hard-coded into
+GitReleaseManager, it is possible to configure them by overriding the list.  See
+[Default Configuration](../configuration/default-configuration.md) for more details.
 :::
 
 ## **Required Parameters**

--- a/src/GitReleaseManager.Core.Tests/Commands/LabelCommandTests.cs
+++ b/src/GitReleaseManager.Core.Tests/Commands/LabelCommandTests.cs
@@ -32,13 +32,13 @@ namespace GitReleaseManager.Core.Tests.Commands
                 RepositoryName = "repository",
             };
 
-            _vcsService.CreateLabelsAsync(options.RepositoryOwner, options.RepositoryName)
+            _vcsService.CreateOrUpdateLabelsAsync(options.RepositoryOwner, options.RepositoryName)
                 .Returns(Task.CompletedTask);
 
             var result = await _command.Execute(options).ConfigureAwait(false);
             result.ShouldBe(0);
 
-            await _vcsService.Received(1).CreateLabelsAsync(options.RepositoryOwner, options.RepositoryName).ConfigureAwait(false);
+            await _vcsService.Received(1).CreateOrUpdateLabelsAsync(options.RepositoryOwner, options.RepositoryName).ConfigureAwait(false);
             _logger.Received(1).Information(Arg.Any<string>());
         }
     }

--- a/src/GitReleaseManager.Core.Tests/VcsServiceTests.cs
+++ b/src/GitReleaseManager.Core.Tests/VcsServiceTests.cs
@@ -211,7 +211,7 @@ namespace GitReleaseManager.Core.Tests
             _vcsProvider.CreateLabelAsync(OWNER, REPOSITORY, Arg.Any<Label>())
                 .Returns(Task.CompletedTask);
 
-            await _vcsService.CreateLabelsAsync(OWNER, REPOSITORY).ConfigureAwait(false);
+            await _vcsService.CreateOrUpdateLabelsAsync(OWNER, REPOSITORY).ConfigureAwait(false);
 
             await _vcsProvider.Received(1).GetLabelsAsync(OWNER, REPOSITORY).ConfigureAwait(false);
             await _vcsProvider.Received(labels.Count).DeleteLabelAsync(OWNER, REPOSITORY, Arg.Any<string>()).ConfigureAwait(false);
@@ -227,7 +227,7 @@ namespace GitReleaseManager.Core.Tests
         {
             _configuration.Labels.Clear();
 
-            await _vcsService.CreateLabelsAsync(OWNER, REPOSITORY).ConfigureAwait(false);
+            await _vcsService.CreateOrUpdateLabelsAsync(OWNER, REPOSITORY).ConfigureAwait(false);
 
             _logger.Received(1).Warning(Arg.Any<string>());
         }

--- a/src/GitReleaseManager.Core/Commands/LabelCommand.cs
+++ b/src/GitReleaseManager.Core/Commands/LabelCommand.cs
@@ -18,7 +18,7 @@ namespace GitReleaseManager.Core.Commands
         public async Task<int> Execute(LabelSubOptions options)
         {
             _logger.Information("Creating standard labels");
-            await _vcsService.CreateLabelsAsync(options.RepositoryOwner, options.RepositoryName).ConfigureAwait(false);
+            await _vcsService.CreateOrUpdateLabelsAsync(options.RepositoryOwner, options.RepositoryName).ConfigureAwait(false);
 
             return 0;
         }

--- a/src/GitReleaseManager.Core/Configuration/LabelConfig.cs
+++ b/src/GitReleaseManager.Core/Configuration/LabelConfig.cs
@@ -4,13 +4,12 @@ namespace GitReleaseManager.Core.Configuration
 {
     public class LabelConfig
     {
-        [YamlMember(Alias = "name")]
-        public string Name { get; set; }
+        [YamlMember(Alias = "name")] public string Name { get; set; }
 
-        [YamlMember(Alias = "description")]
-        public string Description { get; set; }
+        [YamlMember(Alias = "description")] public string Description { get; set; }
 
-        [YamlMember(Alias = "color")]
-        public string Color { get; set; }
+        [YamlMember(Alias = "color")] public string Color { get; set; }
+
+        [YamlMember(Alias = "renameFrom")] public string RenameFrom { get; set; }
     }
 }

--- a/src/GitReleaseManager.Core/IVcsService.cs
+++ b/src/GitReleaseManager.Core/IVcsService.cs
@@ -24,6 +24,6 @@ namespace GitReleaseManager.Core
 
         Task PublishReleaseAsync(string owner, string repository, string tagName);
 
-        Task CreateLabelsAsync(string owner, string repository);
+        Task CreateOrUpdateLabelsAsync(string owner, string repository);
     }
 }

--- a/src/GitReleaseManager.Core/Provider/GitHubProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/GitHubProvider.cs
@@ -152,6 +152,16 @@ namespace GitReleaseManager.Core.Provider
             });
         }
 
+        public Task UpdateLabelAsync(string owner, string repository, string originalName, Label label)
+        {
+            return ExecuteAsync(async () =>
+            {
+                var updatedLabel = _mapper.Map<LabelUpdate>(label);
+
+                await _gitHubClient.Issue.Labels.Update(owner, repository, originalName, updatedLabel);
+            });
+        }
+
         public Task DeleteLabelAsync(string owner, string repository, string labelName)
         {
             return ExecuteAsync(async () =>

--- a/src/GitReleaseManager.Core/Provider/IVcsProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/IVcsProvider.cs
@@ -21,6 +21,8 @@ namespace GitReleaseManager.Core.Provider
         Task<IEnumerable<IssueComment>> GetIssueCommentsAsync(string owner, string repository, int issueNumber);
 
         Task CreateLabelAsync(string owner, string repository, Label label);
+        
+        Task UpdateLabelAsync(string owner, string repository, string existingLabelName,Label label);
 
         Task DeleteLabelAsync(string owner, string repository, string labelName);
 

--- a/src/GitReleaseManager.Core/VcsService.cs
+++ b/src/GitReleaseManager.Core/VcsService.cs
@@ -318,6 +318,13 @@ namespace GitReleaseManager.Core
                     }
                     else
                     {
+                        if (!string.IsNullOrEmpty(label.RenameFrom))
+                        {
+                            _logger.Warning(
+                                "Label '{RenameFrom}' does not exist, creating new label '{Name}' instead",
+                                label.RenameFrom, label.Name);
+                        }
+
                         newLabels.Add(newLabel);
                     }
                 }

--- a/src/GitReleaseManager.Tests/VcsServiceMock.cs
+++ b/src/GitReleaseManager.Tests/VcsServiceMock.cs
@@ -70,7 +70,7 @@ namespace GitReleaseManager.Tests
             throw new System.NotImplementedException();
         }
 
-        public Task CreateLabelsAsync(string owner, string repository)
+        public Task CreateOrUpdateLabelsAsync(string owner, string repository)
         {
             throw new System.NotImplementedException();
         }


### PR DESCRIPTION
## Description
Introduce a change to the label command and service method to rename existing labels using an optional RenameFrom property. This property is then used to rename the label with the UpdateLabel OctoKit API call. If the RenameFrom property does not match any existing label, the associated label will **still be deleted** as we're used to, but also a warning is thrown to make the user aware that they might have lost a label in the process.

## Related Issue
#492 
 
## Motivation and Context
It makes integrating existing repos or migrating already GRM equipped repos to new label formats easier.
Instead of 

## How Has This Been Tested?
Could not get that to work (yet). Waiting for feedback first, hope to update the PR accordingly.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
