### PR TITLE
Add support for GitLab

### DIFF
--- a/src/GitReleaseManager.Cli/Program.cs
+++ b/src/GitReleaseManager.Cli/Program.cs
@@ -202,17 +202,15 @@ namespace GitReleaseManager.Cli
             Log.Information("Using {Provider} as VCS Provider", vcsOptions.Provider);
             if (vcsOptions.Provider == VcsProvider.GitLab)
             {
-                var gitlabClient = new GitLabClient("https://gitlab.com", vcsOptions.Token);
                 serviceCollection
-                    .AddSingleton<IVcsProvider, GitLabProvider>()
-                    .AddSingleton<IGitLabClient>(gitlabClient);
+                    .AddSingleton<IGitLabClient>((_) => new GitLabClient("https://gitlab.com", vcsOptions.Token))
+                    .AddSingleton<IVcsProvider, GitLabProvider>();
             }
             else
             {
                 // default to Github
-                var gitHubClient = new GitHubClient(new ProductHeaderValue("GitReleaseManager")) { Credentials = new Credentials(vcsOptions.Token) };
                 serviceCollection
-                    .AddSingleton<IGitHubClient>(gitHubClient)
+                    .AddSingleton<IGitHubClient>((_) => new GitHubClient(new ProductHeaderValue("GitReleaseManager")) { Credentials = new Credentials(vcsOptions.Token) })
                     .AddSingleton<IVcsProvider, GitHubProvider>();
             }
         }

--- a/src/GitReleaseManager.Cli/Program.cs
+++ b/src/GitReleaseManager.Cli/Program.cs
@@ -8,11 +8,13 @@ using GitReleaseManager.Core;
 using GitReleaseManager.Core.Commands;
 using GitReleaseManager.Core.Configuration;
 using GitReleaseManager.Core.Helpers;
+using GitReleaseManager.Core.Model;
 using GitReleaseManager.Core.Options;
 using GitReleaseManager.Core.Provider;
 using GitReleaseManager.Core.ReleaseNotes;
 using GitReleaseManager.Core.Templates;
 using Microsoft.Extensions.DependencyInjection;
+using NGitLab;
 using Octokit;
 using Serilog;
 
@@ -96,7 +98,6 @@ namespace GitReleaseManager.Cli
                 .AddSingleton<IFileSystem>(fileSystem)
                 .AddSingleton<IReleaseNotesExporter, ReleaseNotesExporter>()
                 .AddSingleton<IReleaseNotesBuilder, ReleaseNotesBuilder>()
-                .AddSingleton<IVcsProvider, GitHubProvider>()
                 .AddSingleton<IVcsService, VcsService>();
 
             if (options is BaseVcsOptions vcsOptions)
@@ -106,9 +107,7 @@ namespace GitReleaseManager.Cli
                     throw new Exception("The token option is not defined");
                 }
 
-                var gitHubClient = new GitHubClient(new ProductHeaderValue("GitReleaseManager")) { Credentials = new Credentials(vcsOptions.Token) };
-                serviceCollection = serviceCollection
-                    .AddSingleton<IGitHubClient>(gitHubClient);
+                RegisterVcsProvider(vcsOptions, serviceCollection);
             }
 
             serviceCollection = serviceCollection
@@ -197,5 +196,25 @@ namespace GitReleaseManager.Cli
 
         private static void LogOptions(BaseSubOptions options)
             => Log.Debug("{@Options}", options);
+
+        private static void RegisterVcsProvider(BaseVcsOptions vcsOptions, IServiceCollection serviceCollection)
+        {
+            Log.Information("Using {Provider} as VCS Provider", vcsOptions.Provider);
+            if (vcsOptions.Provider == VcsProvider.GitLab)
+            {
+                var gitlabClient = new GitLabClient("https://gitlab.com", vcsOptions.Token);
+                serviceCollection
+                    .AddSingleton<IVcsProvider, GitLabProvider>()
+                    .AddSingleton<IGitLabClient>(gitlabClient);
+            }
+            else
+            {
+                // default to Github
+                var gitHubClient = new GitHubClient(new ProductHeaderValue("GitReleaseManager")) { Credentials = new Credentials(vcsOptions.Token) };
+                serviceCollection
+                    .AddSingleton<IGitHubClient>(gitHubClient)
+                    .AddSingleton<IVcsProvider, GitHubProvider>();
+            }
+        }
     }
 }

--- a/src/GitReleaseManager.Core.Tests/Provider/GitHubProviderTests.cs
+++ b/src/GitReleaseManager.Core.Tests/Provider/GitHubProviderTests.cs
@@ -46,7 +46,7 @@ namespace GitReleaseManager.Core.Tests.Provider
         private const bool SKIP_PRERELEASES = false;
 
         private readonly Release _release = new Release { Id = RELEASE_ID };
-        private readonly Issue _issue = new Issue { Number = ISSUE_NUMBER };
+        private readonly Issue _issue = new Issue { PublicNumber = ISSUE_NUMBER };
         private readonly Milestone _milestone = new Milestone { PublicNumber = MILESTONE_PUBLIC_NUMBER, InternalNumber = MILESTONE_INTERNAL_NUMBER };
         private readonly Label _label = new Label { Name = LABEL_NAME };
         private readonly ReleaseAsset _asset = new ReleaseAsset { Id = ASSET_ID };

--- a/src/GitReleaseManager.Core/Commands/AddAssetsCommand.cs
+++ b/src/GitReleaseManager.Core/Commands/AddAssetsCommand.cs
@@ -21,7 +21,7 @@ namespace GitReleaseManager.Core.Commands
 
             if (vcsOptions?.Provider == Model.VcsProvider.GitLab)
             {
-                _logger.Error("The addasset command is currently not supported when targetting GitLab.");
+                _logger.Error("The 'addasset' command is currently not supported when targeting GitLab.");
                 return 1;
             }
 

--- a/src/GitReleaseManager.Core/Commands/AddAssetsCommand.cs
+++ b/src/GitReleaseManager.Core/Commands/AddAssetsCommand.cs
@@ -17,6 +17,14 @@ namespace GitReleaseManager.Core.Commands
 
         public async Task<int> ExecuteAsync(AddAssetSubOptions options)
         {
+            var vcsOptions = options as BaseVcsOptions;
+
+            if (vcsOptions?.Provider == Model.VcsProvider.GitLab)
+            {
+                _logger.Error("The addasset command is currently not supported when targetting GitLab.");
+                return 1;
+            }
+
             _logger.Information("Uploading assets");
             await _vcsService.AddAssetsAsync(options.RepositoryOwner, options.RepositoryName, options.TagName, options.AssetPaths).ConfigureAwait(false);
 

--- a/src/GitReleaseManager.Core/Commands/ExportCommand.cs
+++ b/src/GitReleaseManager.Core/Commands/ExportCommand.cs
@@ -18,13 +18,13 @@ namespace GitReleaseManager.Core.Commands
 
         public async Task<int> ExecuteAsync(ExportSubOptions options)
         {
-            if (string.IsNullOrEmpty(options.TagName))
+            if (string.IsNullOrWhiteSpace(options.TagName))
             {
-                _logger.Information("Exporting all releases");
+                _logger.Information("Exporting all releases.");
             }
             else
             {
-                _logger.Information("Exporting release {TagName}", options.TagName);
+                _logger.Information("Exporting release {TagName}.", options.TagName);
             }
 
             var releasesContent = await _vcsService.ExportReleasesAsync(options.RepositoryOwner, options.RepositoryName, options.TagName, options.SkipPrereleases).ConfigureAwait(false);

--- a/src/GitReleaseManager.Core/Commands/ExportCommand.cs
+++ b/src/GitReleaseManager.Core/Commands/ExportCommand.cs
@@ -18,7 +18,15 @@ namespace GitReleaseManager.Core.Commands
 
         public async Task<int> ExecuteAsync(ExportSubOptions options)
         {
-            _logger.Information("Exporting release {TagName}", options.TagName);
+            if (string.IsNullOrEmpty(options.TagName))
+            {
+                _logger.Information("Exporting all releases");
+            }
+            else
+            {
+                _logger.Information("Exporting release {TagName}", options.TagName);
+            }
+
             var releasesContent = await _vcsService.ExportReleasesAsync(options.RepositoryOwner, options.RepositoryName, options.TagName, options.SkipPrereleases).ConfigureAwait(false);
 
             using (var sw = new StreamWriter(File.Open(options.FileOutputPath, FileMode.OpenOrCreate)))

--- a/src/GitReleaseManager.Core/Commands/LabelCommand.cs
+++ b/src/GitReleaseManager.Core/Commands/LabelCommand.cs
@@ -21,7 +21,7 @@ namespace GitReleaseManager.Core.Commands
 
             if (vcsOptions?.Provider == Model.VcsProvider.GitLab)
             {
-                _logger.Error("The label command is currently not supported when targetting GitLab.");
+                _logger.Error("The label command is currently not supported when targeting GitLab.");
                 return 1;
             }
 

--- a/src/GitReleaseManager.Core/Commands/LabelCommand.cs
+++ b/src/GitReleaseManager.Core/Commands/LabelCommand.cs
@@ -17,6 +17,14 @@ namespace GitReleaseManager.Core.Commands
 
         public async Task<int> ExecuteAsync(LabelSubOptions options)
         {
+            var vcsOptions = options as BaseVcsOptions;
+
+            if (vcsOptions?.Provider == Model.VcsProvider.GitLab)
+            {
+                _logger.Error("The label command is currently not supported when targetting GitLab.");
+                return 1;
+            }
+
             _logger.Information("Creating standard labels");
             await _vcsService.CreateLabelsAsync(options.RepositoryOwner, options.RepositoryName).ConfigureAwait(false);
 

--- a/src/GitReleaseManager.Core/Configuration/Config.cs
+++ b/src/GitReleaseManager.Core/Configuration/Config.cs
@@ -12,7 +12,7 @@ The release is available on:
 
 - [GitHub release](https://github.com/{owner}/{repository}/releases/tag/{milestone})
 
-Your **[GitReleaseManager](https://github.com/GitTools/GitReleaseManager)** bot :package::rocket:";
+Your **[GitReleaseManager](https://github.com/GitTools/GitReleaseManager)** bot :package: :rocket:";
 
         public Config()
         {

--- a/src/GitReleaseManager.Core/Extensions/MilestoneExtensions.cs
+++ b/src/GitReleaseManager.Core/Extensions/MilestoneExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using Octokit;
 using Serilog;
 
 namespace GitReleaseManager.Core.Extensions
@@ -8,7 +7,30 @@ namespace GitReleaseManager.Core.Extensions
     {
         public static readonly ILogger _logger = Log.ForContext(typeof(MilestoneExtensions));
 
-        public static Version Version(this Milestone ver)
+        public static Version Version(this Octokit.Milestone ver)
+        {
+            if (ver is null)
+            {
+                throw new ArgumentNullException(nameof(ver));
+            }
+
+            var nameWithoutPrerelease = ver.Title.Split('-')[0];
+            if (nameWithoutPrerelease.StartsWith("v", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.Debug("Removing version prefix from {Name}", ver.Title);
+                nameWithoutPrerelease = nameWithoutPrerelease.Remove(0, 1);
+            }
+
+            if (!System.Version.TryParse(nameWithoutPrerelease, out Version parsedVersion))
+            {
+                _logger.Warning("No valid version was found on {Title}", ver.Title);
+                return new Version(0, 0);
+            }
+
+            return parsedVersion;
+        }
+
+        public static Version Version(this NGitLab.Models.Milestone ver)
         {
             if (ver is null)
             {

--- a/src/GitReleaseManager.Core/Extensions/MilestoneExtensions.cs
+++ b/src/GitReleaseManager.Core/Extensions/MilestoneExtensions.cs
@@ -17,13 +17,13 @@ namespace GitReleaseManager.Core.Extensions
             var nameWithoutPrerelease = ver.Title.Split('-')[0];
             if (nameWithoutPrerelease.StartsWith("v", StringComparison.OrdinalIgnoreCase))
             {
-                _logger.Debug("Removing version prefix from {Name}", ver.Title);
+                _logger.Debug("Removing version prefix from {Name}.", ver.Title);
                 nameWithoutPrerelease = nameWithoutPrerelease.Remove(0, 1);
             }
 
             if (!System.Version.TryParse(nameWithoutPrerelease, out Version parsedVersion))
             {
-                _logger.Warning("No valid version was found on {Title}", ver.Title);
+                _logger.Warning("No valid version was found on {Title}.", ver.Title);
                 return new Version(0, 0);
             }
 

--- a/src/GitReleaseManager.Core/GitReleaseManager.Core.csproj
+++ b/src/GitReleaseManager.Core/GitReleaseManager.Core.csproj
@@ -23,6 +23,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="NGitLab" Version="6.39.0" />
         <PackageReference Include="Octokit" Version="7.1.0" />
         <PackageReference Include="Scriban" Version="5.7.0" />
         <PackageReference Include="seriloganalyzer" Version="0.15.0" />

--- a/src/GitReleaseManager.Core/MappingProfiles/GitHubProfile.cs
+++ b/src/GitReleaseManager.Core/MappingProfiles/GitHubProfile.cs
@@ -7,7 +7,10 @@ namespace GitReleaseManager.Core.MappingProfiles
     {
         public GitHubProfile()
         {
-            CreateMap<Model.Issue, Octokit.Issue>().ReverseMap();
+            CreateMap<Octokit.Issue, Model.Issue>()
+                .ForMember(dest => dest.PublicNumber, act => act.MapFrom(src => src.Number))
+                .ForMember(dest => dest.InternalNumber, act => act.MapFrom(src => src.Id))
+                .ReverseMap();
             CreateMap<Model.IssueComment, Octokit.IssueComment>().ReverseMap();
             CreateMap<Model.ItemState, Octokit.ItemState>().ReverseMap();
             CreateMap<Model.ItemStateFilter, Octokit.ItemStateFilter>().ReverseMap();

--- a/src/GitReleaseManager.Core/MappingProfiles/GitHubProfile.cs
+++ b/src/GitReleaseManager.Core/MappingProfiles/GitHubProfile.cs
@@ -20,6 +20,8 @@ namespace GitReleaseManager.Core.MappingProfiles
             CreateMap<Model.Label, Octokit.NewLabel>().ReverseMap();
             CreateMap<Model.Milestone, Octokit.Milestone>();
             CreateMap<Octokit.Milestone, Model.Milestone>()
+                .ForMember(dest => dest.PublicNumber, act => act.MapFrom(src => src.Number))
+                .ForMember(dest => dest.InternalNumber, act => act.MapFrom(src => src.Number))
                 .AfterMap((src, dest) => dest.Version = src.Version());
         }
     }

--- a/src/GitReleaseManager.Core/MappingProfiles/GitHubProfile.cs
+++ b/src/GitReleaseManager.Core/MappingProfiles/GitHubProfile.cs
@@ -10,6 +10,7 @@ namespace GitReleaseManager.Core.MappingProfiles
             CreateMap<Octokit.Issue, Model.Issue>()
                 .ForMember(dest => dest.PublicNumber, act => act.MapFrom(src => src.Number))
                 .ForMember(dest => dest.InternalNumber, act => act.MapFrom(src => src.Id))
+                .ForMember(dest => dest.IsPullRequest, act => act.MapFrom(src => src.HtmlUrl.Contains("/pull/")))
                 .ReverseMap();
             CreateMap<Model.IssueComment, Octokit.IssueComment>().ReverseMap();
             CreateMap<Model.ItemState, Octokit.ItemState>().ReverseMap();

--- a/src/GitReleaseManager.Core/MappingProfiles/GitHubProfile.cs
+++ b/src/GitReleaseManager.Core/MappingProfiles/GitHubProfile.cs
@@ -1,3 +1,4 @@
+using System;
 using AutoMapper;
 using GitReleaseManager.Core.Extensions;
 
@@ -10,7 +11,7 @@ namespace GitReleaseManager.Core.MappingProfiles
             CreateMap<Octokit.Issue, Model.Issue>()
                 .ForMember(dest => dest.PublicNumber, act => act.MapFrom(src => src.Number))
                 .ForMember(dest => dest.InternalNumber, act => act.MapFrom(src => src.Id))
-                .ForMember(dest => dest.IsPullRequest, act => act.MapFrom(src => src.HtmlUrl.Contains("/pull/")))
+                .ForMember(dest => dest.IsPullRequest, act => act.MapFrom(src => src.HtmlUrl.IndexOf("/pull/", StringComparison.OrdinalIgnoreCase) >= 0))
                 .ReverseMap();
             CreateMap<Model.IssueComment, Octokit.IssueComment>().ReverseMap();
             CreateMap<Model.ItemState, Octokit.ItemState>().ReverseMap();

--- a/src/GitReleaseManager.Core/MappingProfiles/GitLabProfile.cs
+++ b/src/GitReleaseManager.Core/MappingProfiles/GitLabProfile.cs
@@ -1,0 +1,48 @@
+namespace GitReleaseManager.Core.MappingProfiles
+{
+    using System;
+    using AutoMapper;
+    using GitReleaseManager.Core.Extensions;
+
+    public class GitLabProfile : Profile
+    {
+        public GitLabProfile()
+        {
+            CreateMap<NGitLab.Models.Milestone, Model.Milestone>()
+                .ForMember(dest => dest.PublicNumber, act => act.MapFrom(src => src.Iid))
+                .ForMember(dest => dest.InternalNumber, act => act.MapFrom(src => src.Id))
+                .AfterMap((src, dest) => dest.Version = src.Version());
+            CreateMap<NGitLab.Models.ReleaseInfo, Model.Release>()
+                .ForMember(dest => dest.Draft, act => act.MapFrom(src => src.ReleasedAt > DateTime.UtcNow))
+                .ForMember(dest => dest.Body, act => act.MapFrom(src => src.Description))
+                .ForMember(dest => dest.Assets, act => act.MapFrom(src => src.Assets.Links))
+                .ReverseMap();
+            CreateMap<NGitLab.Models.ReleaseLink, Model.ReleaseAsset>().ReverseMap();
+            CreateMap<NGitLab.Models.Issue, Model.Issue>()
+                .ForMember(dest => dest.InternalNumber, act => act.MapFrom(src => src.Id))
+                .ForMember(dest => dest.PublicNumber, act => act.MapFrom(src => src.IssueId))
+                .ForMember(dest => dest.HtmlUrl, act => act.MapFrom(src => src.WebUrl))
+                .ForMember(dest => dest.IsPullRequest, act => act.MapFrom(src => false))
+                .ReverseMap();
+            CreateMap<NGitLab.Models.MergeRequest, Model.Issue>()
+                .ForMember(dest => dest.InternalNumber, act => act.MapFrom(src => src.Id))
+                .ForMember(dest => dest.PublicNumber, act => act.MapFrom(src => src.Iid))
+                .ForMember(dest => dest.HtmlUrl, act => act.MapFrom(src => src.WebUrl))
+                .ForMember(dest => dest.IsPullRequest, act => act.MapFrom(src => true))
+                .ReverseMap();
+            CreateMap<string, Model.Label>().ForMember(dest => dest.Name, act => act.MapFrom(src => src));
+            CreateMap<Model.Release, NGitLab.Models.ReleaseCreate>()
+                .ForMember(dest => dest.Description, act => act.MapFrom(src => src.Body))
+                .ForMember(dest => dest.Ref, act => act.MapFrom(src => src.TargetCommitish))
+                .ForMember(dest => dest.Milestones, act => act.MapFrom(src => new string[] { src.TagName }))
+                .ForMember(dest => dest.ReleasedAt, act => act.MapFrom(src => src.Draft ? DateTime.UtcNow.AddYears(1) : DateTime.UtcNow))
+                .ForMember(dest => dest.Assets, act => act.Ignore())
+                .ReverseMap();
+            CreateMap<NGitLab.Models.ProjectIssueNote, Model.IssueComment>()
+                .ForMember(dest => dest.Id, act => act.MapFrom(src => src.NoteId))
+                .ReverseMap();
+            CreateMap<NGitLab.Models.MergeRequestComment, Model.IssueComment>()
+                .ReverseMap();
+        }
+    }
+}

--- a/src/GitReleaseManager.Core/Model/Issue.cs
+++ b/src/GitReleaseManager.Core/Model/Issue.cs
@@ -13,5 +13,7 @@ namespace GitReleaseManager.Core.Model
         public string HtmlUrl { get; set; }
 
         public IReadOnlyList<Label> Labels { get; set; }
+
+        public bool IsPullRequest { get; set; }
     }
 }

--- a/src/GitReleaseManager.Core/Model/Issue.cs
+++ b/src/GitReleaseManager.Core/Model/Issue.cs
@@ -6,7 +6,9 @@ namespace GitReleaseManager.Core.Model
     {
         public string Title { get; set; }
 
-        public int Number { get; set; }
+        public int InternalNumber { get; set; }
+
+        public int PublicNumber { get; set; }
 
         public string HtmlUrl { get; set; }
 

--- a/src/GitReleaseManager.Core/Model/Milestone.cs
+++ b/src/GitReleaseManager.Core/Model/Milestone.cs
@@ -8,7 +8,9 @@ namespace GitReleaseManager.Core.Model
 
         public string Description { get; set; }
 
-        public int Number { get; set; }
+        public int PublicNumber { get; set; }
+
+        public int InternalNumber { get; set; }
 
         public string HtmlUrl { get; set; }
 

--- a/src/GitReleaseManager.Core/Model/VcsProvider.cs
+++ b/src/GitReleaseManager.Core/Model/VcsProvider.cs
@@ -1,0 +1,8 @@
+namespace GitReleaseManager.Core.Model
+{
+    public enum VcsProvider
+    {
+        GitHub = 0,
+        GitLab = 1,
+    }
+}

--- a/src/GitReleaseManager.Core/Options/BaseVcsSubOptions.cs
+++ b/src/GitReleaseManager.Core/Options/BaseVcsSubOptions.cs
@@ -1,5 +1,6 @@
 using CommandLine;
 using Destructurama.Attributed;
+using GitReleaseManager.Core.Model;
 
 namespace GitReleaseManager.Core.Options
 {
@@ -14,5 +15,8 @@ namespace GitReleaseManager.Core.Options
 
         [Option('r', "repository", HelpText = "The name of the repository.", Required = true)]
         public string RepositoryName { get; set; }
+
+        [Option("provider", HelpText = "Version Control System provider", Default = VcsProvider.GitHub)]
+        public VcsProvider Provider { get; set; }
     }
 }

--- a/src/GitReleaseManager.Core/Provider/GitHubProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/GitHubProvider.cs
@@ -351,6 +351,11 @@ namespace GitReleaseManager.Core.Provider
             return "closed=1";
         }
 
+        public string GetIssueType(Issue issue)
+        {
+            return issue.IsPullRequest ? "Pull Request" : "Issue";
+        }
+
         private async Task ExecuteAsync(Func<Task> action)
         {
             try

--- a/src/GitReleaseManager.Core/Provider/GitHubProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/GitHubProvider.cs
@@ -345,6 +345,11 @@ namespace GitReleaseManager.Core.Provider
             }
         }
 
+        public string GetMilestoneQueryString()
+        {
+            return "closed=1";
+        }
+
         private async Task ExecuteAsync(Func<Task> action)
         {
             try

--- a/src/GitReleaseManager.Core/Provider/GitHubProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/GitHubProvider.cs
@@ -89,7 +89,7 @@ namespace GitReleaseManager.Core.Provider
         {
             return ExecuteAsync(async () =>
             {
-                await _gitHubClient.Issue.Comment.Create(owner, repository, issue.Number, comment).ConfigureAwait(false);
+                await _gitHubClient.Issue.Comment.Create(owner, repository, issue.PublicNumber, comment).ConfigureAwait(false);
             });
         }
 
@@ -132,7 +132,7 @@ namespace GitReleaseManager.Core.Provider
                 do
                 {
                     var options = GetApiOptions(startPage);
-                    results = await _gitHubClient.Issue.Comment.GetAllForIssue(owner, repository, issue.Number, options).ConfigureAwait(false);
+                    results = await _gitHubClient.Issue.Comment.GetAllForIssue(owner, repository, issue.PublicNumber, options).ConfigureAwait(false);
 
                     comments.AddRange(results);
                     startPage++;

--- a/src/GitReleaseManager.Core/Provider/GitLabProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/GitLabProvider.cs
@@ -1,0 +1,440 @@
+namespace GitReleaseManager.Core.Provider
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AutoMapper;
+    using NGitLab;
+    using NGitLab.Models;
+    using Serilog;
+    using ApiException = GitReleaseManager.Core.Exceptions.ApiException;
+    using Issue = GitReleaseManager.Core.Model.Issue;
+    using IssueComment = GitReleaseManager.Core.Model.IssueComment;
+    using ItemState = GitReleaseManager.Core.Model.ItemState;
+    using ItemStateFilter = GitReleaseManager.Core.Model.ItemStateFilter;
+    using Label = GitReleaseManager.Core.Model.Label;
+    using Milestone = GitReleaseManager.Core.Model.Milestone;
+    using NotFoundException = GitReleaseManager.Core.Exceptions.NotFoundException;
+    using RateLimit = GitReleaseManager.Core.Model.RateLimit;
+    using Release = GitReleaseManager.Core.Model.Release;
+    using ReleaseAsset = GitReleaseManager.Core.Model.ReleaseAsset;
+    using ReleaseAssetUpload = GitReleaseManager.Core.Model.ReleaseAssetUpload;
+
+    public class GitLabProvider : IVcsProvider
+    {
+        private const string NOT_FOUND_MESSGAE = "NotFound";
+        private const string COMMITS_FORMAT_STRING = "https://gitlab.com/{0}/{1}/-/commits/{2}";
+        private const string COMPARE_FORMAT_STRING = "https://gitlab.com/{0}/{1}/-/compare/{2}...{3}";
+        private const string MILESTONES_FORMAT_STRING = "https://gitlab.com/{0}/{1}/-/milestones/{2}#tab-issues";
+        private const string RELEASES_FORMAT_STRING = "https://gitlab.com/{0}/{1}/-/releases/{2}";
+
+        private readonly IGitLabClient _gitLabClient;
+        private readonly IMapper _mapper;
+        private readonly ILogger _logger;
+
+        private int? _projectId;
+
+        public GitLabProvider(IGitLabClient gitLabClient, IMapper mapper, ILogger logger)
+        {
+            _gitLabClient = gitLabClient;
+            _mapper = mapper;
+            _logger = logger;
+        }
+
+        public Task DeleteAssetAsync(string owner, string repository, ReleaseAsset asset)
+        {
+            // TODO: This is a discussion here:
+            // https://github.com/ubisoft/NGitLab/discussions/511
+            // about what is necessary to implement the required functionality in NGitLab
+            throw new NotImplementedException();
+        }
+
+        public Task UploadAssetAsync(Release release, ReleaseAssetUpload releaseAssetUpload)
+        {
+            return ExecuteAsync(() =>
+            {
+                _logger.Warning("Uploading of assets is not currently supported when targeting GitLab.");
+                return Task.CompletedTask;
+            });
+        }
+
+        public Task<int> GetCommitsCountAsync(string owner, string repository, string @base, string head)
+        {
+            return ExecuteAsync(() =>
+            {
+                // TODO: This is waiting on a PR being merged...
+                // https://github.com/ubisoft/NGitLab/pull/444
+                // Once it is, we might be able to implement what is necessary here.
+                return Task.FromResult(0);
+            });
+        }
+
+        public string GetCommitsUrl(string owner, string repository, string head, string @base = null)
+        {
+            Ensure.IsNotNullOrWhiteSpace(owner, nameof(owner));
+            Ensure.IsNotNullOrWhiteSpace(repository, nameof(repository));
+            Ensure.IsNotNullOrWhiteSpace(head, nameof(head));
+
+            return string.IsNullOrWhiteSpace(@base)
+                ? string.Format(CultureInfo.InvariantCulture, COMMITS_FORMAT_STRING, owner, repository, head)
+                : string.Format(CultureInfo.InvariantCulture, COMPARE_FORMAT_STRING, owner, repository, @base, head);
+        }
+
+        public Task CreateIssueCommentAsync(string owner, string repository, Issue issue, string comment)
+        {
+            return ExecuteAsync(() =>
+            {
+                var projectId = GetGitLabProjectId(owner, repository);
+
+                if (issue.IsPullRequest)
+                {
+                    var mergeRequestClient = _gitLabClient.GetMergeRequest(projectId);
+                    var commentsClient = mergeRequestClient.Comments(issue.PublicNumber);
+                    var mergeRequestComment = new MergeRequestCommentCreate
+                    {
+                        Body = comment,
+                    };
+
+                    commentsClient.Add(mergeRequestComment);
+                }
+                else
+                {
+                    var issueNotesClient = _gitLabClient.GetProjectIssueNoteClient(projectId);
+                    var issueComment = new ProjectIssueNoteCreate
+                    {
+                        IssueId = issue.PublicNumber,
+                        Body = comment,
+                    };
+
+                    issueNotesClient.Create(issueComment);
+                }
+
+                return Task.CompletedTask;
+            });
+        }
+
+        public Task<IEnumerable<Issue>> GetIssuesAsync(string owner, string repository, Milestone milestone, ItemStateFilter itemStateFilter = ItemStateFilter.All)
+        {
+            return ExecuteAsync(() =>
+            {
+                var issuesClient = _gitLabClient.Issues;
+
+                var query = new IssueQuery();
+                query.Milestone = milestone.Title;
+
+                if (itemStateFilter == ItemStateFilter.Open)
+                {
+                    query.State = IssueState.opened;
+                }
+                else if (itemStateFilter == ItemStateFilter.Closed)
+                {
+                    query.State = IssueState.closed;
+                }
+
+                var projectId = GetGitLabProjectId(owner, repository);
+
+                var issues = issuesClient.GetAsync(projectId, query);
+
+                var mergeRequestsClient = _gitLabClient.GetMergeRequest(projectId);
+
+                var mergeRequestQuery = new MergeRequestQuery();
+                mergeRequestQuery.Milestone = milestone.Title;
+
+                if (itemStateFilter == ItemStateFilter.Open)
+                {
+                    mergeRequestQuery.State = MergeRequestState.opened;
+                }
+                else if (itemStateFilter == ItemStateFilter.Closed)
+                {
+                    mergeRequestQuery.State = MergeRequestState.merged;
+                }
+
+                var mergeRequests = mergeRequestsClient.Get(mergeRequestQuery);
+
+                var issuesAndMergeRequests = new List<Issue>();
+                issuesAndMergeRequests.AddRange(_mapper.Map<IEnumerable<Issue>>(issues));
+                issuesAndMergeRequests.AddRange(_mapper.Map<IEnumerable<Issue>>(mergeRequests));
+
+                return Task.FromResult(issuesAndMergeRequests.AsEnumerable());
+            });
+        }
+
+        public Task<IEnumerable<IssueComment>> GetIssueCommentsAsync(string owner, string repository, Issue issue)
+        {
+            return ExecuteAsync(() =>
+            {
+                IEnumerable<IssueComment> issueComments = Enumerable.Empty<IssueComment>();
+                var projectId = GetGitLabProjectId(owner, repository);
+
+                if (issue.IsPullRequest)
+                {
+                    var mergeRequestClient = _gitLabClient.GetMergeRequest(projectId);
+                    var commentsClient = mergeRequestClient.Comments(issue.PublicNumber);
+                    var comments = commentsClient.All;
+                    issueComments = _mapper.Map<IEnumerable<IssueComment>>(comments);
+                }
+                else
+                {
+                    var issueNotesClient = _gitLabClient.GetProjectIssueNoteClient(projectId);
+                    var comments = issueNotesClient.ForIssue(issue.PublicNumber);
+                    issueComments = _mapper.Map<IEnumerable<IssueComment>>(comments);
+                }
+
+                return Task.FromResult(issueComments);
+            });
+        }
+
+        public Task CreateLabelAsync(string owner, string repository, Label label)
+        {
+            // The label functionality in GitLab already provides more than
+            // what is possible in GRM. As such, the decision was taken to not
+            // implement the creation of labels for the GitLab provider.
+            throw new NotImplementedException();
+        }
+
+        public Task DeleteLabelAsync(string owner, string repository, Label label)
+        {
+            // The label functionality in GitLab already provides more than
+            // what is possible in GRM. As such, the decision was taken to not
+            // implement the deletion of labels for the GitLab provider.
+            throw new NotImplementedException();
+        }
+
+        public Task<IEnumerable<Label>> GetLabelsAsync(string owner, string repository)
+        {
+            // The label functionality in GitLab already provides more than
+            // what is possible in GRM. As such, the decision was taken to not
+            // implement the fetching of labels for the GitLab provider.
+            throw new NotImplementedException();
+        }
+
+        public Task<Milestone> GetMilestoneAsync(string owner, string repository, string milestoneTitle, ItemStateFilter itemStateFilter = ItemStateFilter.All)
+        {
+            return ExecuteAsync(async () =>
+            {
+                var milestones = await GetMilestonesAsync(owner, repository, itemStateFilter).ConfigureAwait(false);
+                var foundMilestone = milestones.FirstOrDefault(m => m.Title == milestoneTitle);
+
+                if (foundMilestone is null)
+                {
+                    throw new NotFoundException(NOT_FOUND_MESSGAE);
+                }
+
+                return foundMilestone;
+            });
+        }
+
+        public Task<IEnumerable<Milestone>> GetMilestonesAsync(string owner, string repository, ItemStateFilter itemStateFilter = ItemStateFilter.All)
+        {
+            return ExecuteAsync(() =>
+            {
+                var query = new MilestoneQuery();
+
+                if (itemStateFilter == ItemStateFilter.Open)
+                {
+                    query.State = MilestoneState.active;
+                }
+                else if (itemStateFilter == ItemStateFilter.Closed)
+                {
+                    query.State = MilestoneState.closed;
+                }
+
+                var mileStoneClient = _gitLabClient.GetMilestone(GetGitLabProjectId(owner, repository));
+
+                var milestones = mileStoneClient.Get(query);
+                var mappedMilestones = _mapper.Map<IEnumerable<Milestone>>(milestones);
+
+                foreach (var mappedMilestone in mappedMilestones)
+                {
+                    mappedMilestone.HtmlUrl = string.Format(CultureInfo.InvariantCulture, MILESTONES_FORMAT_STRING, owner, repository, mappedMilestone.PublicNumber);
+                }
+
+                return Task.FromResult(mappedMilestones);
+            });
+        }
+
+        public Task SetMilestoneStateAsync(string owner, string repository, Milestone milestone, ItemState itemState)
+        {
+            return ExecuteAsync(() =>
+            {
+                var mileStoneClient = _gitLabClient.GetMilestone(GetGitLabProjectId(owner, repository));
+
+                if (itemState == ItemState.Open)
+                {
+                    mileStoneClient.Activate(milestone.InternalNumber);
+                }
+                else if (itemState == ItemState.Closed)
+                {
+                    mileStoneClient.Close(milestone.InternalNumber);
+                }
+
+                return Task.CompletedTask;
+            });
+        }
+
+        public Task<Release> CreateReleaseAsync(string owner, string repository, Release release)
+        {
+            return ExecuteAsync(() =>
+            {
+                var releaseClient = _gitLabClient.GetReleases(GetGitLabProjectId(owner, repository));
+
+                var newRelease = _mapper.Map<ReleaseCreate>(release);
+                var nGitLabRelease = releaseClient.Create(newRelease);
+                var mappedRelease = _mapper.Map<Release>(nGitLabRelease);
+
+                if (mappedRelease != null)
+                {
+                    mappedRelease.HtmlUrl = string.Format(CultureInfo.InvariantCulture, RELEASES_FORMAT_STRING, owner, repository, release.TagName);
+                }
+
+                return Task.FromResult(mappedRelease);
+            });
+        }
+
+        public Task DeleteReleaseAsync(string owner, string repository, Release release)
+        {
+            return ExecuteAsync(() =>
+            {
+                var releaseClient = _gitLabClient.GetReleases(GetGitLabProjectId(owner, repository));
+
+                releaseClient.Delete(release.TagName);
+                return Task.CompletedTask;
+            });
+        }
+
+        public Task<Release> GetReleaseAsync(string owner, string repository, string tagName)
+        {
+            return ExecuteAsync(() =>
+            {
+                var releaseClient = _gitLabClient.GetReleases(GetGitLabProjectId(owner, repository));
+
+                var releases = releaseClient.GetAsync();
+
+                var release = releases.FirstOrDefault(r => r.TagName == tagName);
+                var mappedRelease = _mapper.Map<Release>(release);
+
+                if (mappedRelease != null)
+                {
+                    mappedRelease.HtmlUrl = string.Format(CultureInfo.InvariantCulture, RELEASES_FORMAT_STRING, owner, repository, tagName);
+                }
+
+                return Task.FromResult(mappedRelease);
+            });
+        }
+
+        public Task<IEnumerable<Release>> GetReleasesAsync(string owner, string repository, bool skipPrereleases)
+        {
+            return ExecuteAsync(() =>
+            {
+                var releaseClient = _gitLabClient.GetReleases(GetGitLabProjectId(owner, repository));
+
+                var releases = _mapper.Map<IEnumerable<Release>>(releaseClient.GetAsync());
+
+                return Task.FromResult(releases);
+            });
+        }
+
+        public Task PublishReleaseAsync(string owner, string repository, string tagName, Release release)
+        {
+            return ExecuteAsync(() =>
+            {
+                var releaseClient = _gitLabClient.GetReleases(GetGitLabProjectId(owner, repository));
+
+                var update = new ReleaseUpdate
+                {
+                    ReleasedAt = DateTime.UtcNow,
+                    TagName = tagName,
+                };
+
+                releaseClient.Update(update);
+                return Task.CompletedTask;
+            });
+        }
+
+        public Task UpdateReleaseAsync(string owner, string repository, Release release)
+        {
+            return ExecuteAsync(() =>
+            {
+                var releaseClient = _gitLabClient.GetReleases(GetGitLabProjectId(owner, repository));
+
+                var update = new ReleaseUpdate
+                {
+                    Description = release.Body,
+                    ReleasedAt = release.Draft ? DateTime.UtcNow.AddYears(1) : DateTime.UtcNow,
+                    Name = release.Name,
+                    TagName = release.TagName,
+                    Milestones = new string[] { release.TagName },
+                };
+
+                releaseClient.Update(update);
+                return Task.CompletedTask;
+            });
+        }
+
+        public RateLimit GetRateLimit()
+        {
+            // TODO: There doesn't currently seem to be a way to get the remaining
+            // rate limit for GitLab using the library we are using, so for now,
+            // let's just hard code it.
+            return new RateLimit { Limit = 600, Remaining = 100 };
+        }
+
+        public string GetMilestoneQueryString()
+        {
+            return "state=closed";
+        }
+
+        public string GetIssueType(Issue issue)
+        {
+            return issue.IsPullRequest ? "Merge Request" : "Issue";
+        }
+
+        private int GetGitLabProjectId(string owner, string repository)
+        {
+            if (_projectId.HasValue)
+            {
+                return _projectId.Value;
+            }
+
+            var projectName = string.Format(CultureInfo.InvariantCulture, "{0}/{1}", owner, repository);
+            var project = _gitLabClient.Projects[projectName];
+            _projectId = project.Id;
+
+            return _projectId.Value;
+        }
+
+        private async Task ExecuteAsync(Func<Task> action)
+        {
+            try
+            {
+                await action().ConfigureAwait(false);
+            }
+            catch (AggregateException ae) when (ae.InnerException != null)
+            {
+                throw new ApiException(ae.InnerException.Message, ae.InnerException);
+            }
+            catch (Exception ex) when (!(ex is NotFoundException))
+            {
+                throw new ApiException(ex.Message, ex);
+            }
+        }
+
+        private async Task<T> ExecuteAsync<T>(Func<Task<T>> action)
+        {
+            try
+            {
+                return await action().ConfigureAwait(false);
+            }
+            catch (AggregateException ae) when (ae.InnerException != null)
+            {
+                throw new ApiException(ae.InnerException.Message, ae.InnerException);
+            }
+            catch (Exception ex) when (!(ex is NotFoundException))
+            {
+                throw new ApiException(ex.Message, ex);
+            }
+        }
+    }
+}

--- a/src/GitReleaseManager.Core/Provider/IVcsProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/IVcsProvider.cs
@@ -45,5 +45,7 @@ namespace GitReleaseManager.Core.Provider
         Task UpdateReleaseAsync(string owner, string repository, Release release);
 
         RateLimit GetRateLimit();
+
+        string GetMilestoneQueryString();
     }
 }

--- a/src/GitReleaseManager.Core/Provider/IVcsProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/IVcsProvider.cs
@@ -6,7 +6,7 @@ namespace GitReleaseManager.Core.Provider
 {
     public interface IVcsProvider
     {
-        Task DeleteAssetAsync(string owner, string repository, int id);
+        Task DeleteAssetAsync(string owner, string repository, ReleaseAsset asset);
 
         Task UploadAssetAsync(Release release, ReleaseAssetUpload releaseAssetUpload);
 
@@ -14,15 +14,15 @@ namespace GitReleaseManager.Core.Provider
 
         string GetCommitsUrl(string owner, string repository, string head, string @base = null);
 
-        Task CreateIssueCommentAsync(string owner, string repository, int issueNumber, string comment);
+        Task CreateIssueCommentAsync(string owner, string repository, Issue issue, string comment);
 
-        Task<IEnumerable<Issue>> GetIssuesAsync(string owner, string repository, int milestoneNumber, ItemStateFilter itemStateFilter = ItemStateFilter.All);
+        Task<IEnumerable<Issue>> GetIssuesAsync(string owner, string repository, Milestone milstone, ItemStateFilter itemStateFilter = ItemStateFilter.All);
 
-        Task<IEnumerable<IssueComment>> GetIssueCommentsAsync(string owner, string repository, int issueNumber);
+        Task<IEnumerable<IssueComment>> GetIssueCommentsAsync(string owner, string repository, Issue issue);
 
         Task CreateLabelAsync(string owner, string repository, Label label);
 
-        Task DeleteLabelAsync(string owner, string repository, string labelName);
+        Task DeleteLabelAsync(string owner, string repository, Label label);
 
         Task<IEnumerable<Label>> GetLabelsAsync(string owner, string repository);
 
@@ -30,17 +30,17 @@ namespace GitReleaseManager.Core.Provider
 
         Task<IEnumerable<Milestone>> GetMilestonesAsync(string owner, string repository, ItemStateFilter itemStateFilter = ItemStateFilter.All);
 
-        Task SetMilestoneStateAsync(string owner, string repository, int milestoneNumber, ItemState itemState);
+        Task SetMilestoneStateAsync(string owner, string repository, Milestone milestone, ItemState itemState);
 
         Task<Release> CreateReleaseAsync(string owner, string repository, Release release);
 
-        Task DeleteReleaseAsync(string owner, string repository, int id);
+        Task DeleteReleaseAsync(string owner, string repository, Release release);
 
         Task<Release> GetReleaseAsync(string owner, string repository, string tagName);
 
         Task<IEnumerable<Release>> GetReleasesAsync(string owner, string repository, bool skipPrereleases);
 
-        Task PublishReleaseAsync(string owner, string repository, string tagName, int releaseId);
+        Task PublishReleaseAsync(string owner, string repository, string tagName, Release release);
 
         Task UpdateReleaseAsync(string owner, string repository, Release release);
 

--- a/src/GitReleaseManager.Core/Provider/IVcsProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/IVcsProvider.cs
@@ -47,5 +47,7 @@ namespace GitReleaseManager.Core.Provider
         RateLimit GetRateLimit();
 
         string GetMilestoneQueryString();
+
+        string GetIssueType(Issue issue);
     }
 }

--- a/src/GitReleaseManager.Core/ReleaseNotes/ReleaseNotesBuilder.cs
+++ b/src/GitReleaseManager.Core/ReleaseNotes/ReleaseNotesBuilder.cs
@@ -184,7 +184,7 @@ namespace GitReleaseManager.Core.ReleaseNotes
 
         private async Task<List<Issue>> GetIssuesAsync(Milestone milestone)
         {
-            var allIssues = await _vcsProvider.GetIssuesAsync(_user, _repository, milestone.Number, ItemStateFilter.Closed).ConfigureAwait(false);
+            var allIssues = await _vcsProvider.GetIssuesAsync(_user, _repository, milestone, ItemStateFilter.Closed).ConfigureAwait(false);
 
             var result = CheckIssuesForValidLabels(allIssues);
 

--- a/src/GitReleaseManager.Core/ReleaseNotes/ReleaseNotesBuilder.cs
+++ b/src/GitReleaseManager.Core/ReleaseNotes/ReleaseNotesBuilder.cs
@@ -106,7 +106,7 @@ namespace GitReleaseManager.Core.ReleaseNotes
                 .Where(o => issueLabels.Any(il => string.Equals(il, o.Label, StringComparison.OrdinalIgnoreCase)))
                 .GroupBy(o => o.Label, o => o.Issue)
                 .OrderBy(o => o.Key)
-                .ToDictionary(o => GetValidLabel(o.Key, o.Count()), o => o.OrderBy(issue => issue.Number).ToList());
+                .ToDictionary(o => GetValidLabel(o.Key, o.Count()), o => o.OrderBy(issue => issue.PublicNumber).ToList());
 
             return issuesByLabel;
         }

--- a/src/GitReleaseManager.Core/ReleaseNotes/ReleaseNotesBuilder.cs
+++ b/src/GitReleaseManager.Core/ReleaseNotes/ReleaseNotesBuilder.cs
@@ -60,7 +60,7 @@ namespace GitReleaseManager.Core.ReleaseNotes
 
             if (issues.Count == 0)
             {
-                var logMessage = string.Format(CultureInfo.InvariantCulture, "No closed issues have been found for milestone {0}, or all assigned issues are meant to be excluded from release notes, aborting creation of release.", _milestoneTitle);
+                var logMessage = string.Format(CultureInfo.CurrentCulture, "No closed issues have been found for milestone {0}, or all assigned issues are meant to be excluded from release notes, aborting release creation.", _milestoneTitle);
                 throw new InvalidOperationException(logMessage);
             }
 

--- a/src/GitReleaseManager.Core/ReleaseNotes/ReleaseNotesBuilder.cs
+++ b/src/GitReleaseManager.Core/ReleaseNotes/ReleaseNotesBuilder.cs
@@ -68,6 +68,8 @@ namespace GitReleaseManager.Core.ReleaseNotes
 
             var issuesDict = GetIssuesDict(issues);
 
+            var milestoneQueryString = _vcsProvider.GetMilestoneQueryString();
+
             var templateModel = new
             {
                 Issues = new
@@ -84,6 +86,7 @@ namespace GitReleaseManager.Core.ReleaseNotes
                 {
                     Target = _targetMilestone,
                     Previous = previousMilestone,
+                    QueryString = milestoneQueryString,
                 },
                 IssueLabels = issuesDict.Keys.ToList(),
             };

--- a/src/GitReleaseManager.Core/ReleaseNotes/ReleaseNotesBuilder.cs
+++ b/src/GitReleaseManager.Core/ReleaseNotes/ReleaseNotesBuilder.cs
@@ -60,7 +60,7 @@ namespace GitReleaseManager.Core.ReleaseNotes
 
             if (issues.Count == 0)
             {
-                var logMessage = string.Format("No closed issues have been found for milestone {0}, or all assigned issues are meant to be excluded from release notes, aborting creation of release.", _milestoneTitle);
+                var logMessage = string.Format(CultureInfo.InvariantCulture, "No closed issues have been found for milestone {0}, or all assigned issues are meant to be excluded from release notes, aborting creation of release.", _milestoneTitle);
                 throw new InvalidOperationException(logMessage);
             }
 

--- a/src/GitReleaseManager.Core/Templates/default/issue-note.sbn
+++ b/src/GitReleaseManager.Core/Templates/default/issue-note.sbn
@@ -1,1 +1,1 @@
-- [__#{{ issue.number }}__]({{ issue.html_url }}) {{ issue.title }}
+- [__#{{ issue.public_number }}__]({{ issue.html_url }}) {{ issue.title }}

--- a/src/GitReleaseManager.Core/Templates/default/issue-note.sbn
+++ b/src/GitReleaseManager.Core/Templates/default/issue-note.sbn
@@ -1,1 +1,6 @@
-- [__#{{ issue.public_number }}__]({{ issue.html_url }}) {{ issue.title }}
+{{
+    if issue.is_pull_request
+}}- [__!{{ issue.public_number }}__]({{ issue.html_url }}) {{ issue.title }}
+{{  else
+}}- [__#{{ issue.public_number }}__]({{ issue.html_url }}) {{ issue.title }}
+{{  end -}}

--- a/src/GitReleaseManager.Core/Templates/default/release-info.sbn
+++ b/src/GitReleaseManager.Core/Templates/default/release-info.sbn
@@ -1,9 +1,9 @@
 {{
     if issues.count > 0
         if commits.count > 0
-}}As part of this release we had [{{ commits.count }} {{ commits.count | string.pluralize "commit" "commits" }}]({{ commits.html_url }}) which resulted in [{{ issues.count }} {{ issues.count | string.pluralize "issue" "issues" }}]({{ milestone.target.html_url }}?closed=1) being closed.
+}}As part of this release we had [{{ commits.count }} {{ commits.count | string.pluralize "commit" "commits" }}]({{ commits.html_url }}) which resulted in [{{ issues.count }} {{ issues.count | string.pluralize "issue" "issues" }}]({{ milestone.target.html_url }}?{{ milestone.query_string }}) being closed.
 {{      else
-}}As part of this release we had [{{ issues.count }} {{ issues.count | string.pluralize "issue" "issues" }}]({{ milestone.target.html_url }}?closed=1) closed.
+}}As part of this release we had [{{ issues.count }} {{ issues.count | string.pluralize "issue" "issues" }}]({{ milestone.target.html_url }}?{{ milestone.query_string }}) closed.
 {{      end
     else if commits.count > 0
 }}As part of this release we had [{{ commits.count }} {{ commits.count | string.pluralize "commit" "commits" }}]({{ commits.html_url }}).

--- a/src/GitReleaseManager.Core/VcsService.cs
+++ b/src/GitReleaseManager.Core/VcsService.cs
@@ -142,7 +142,7 @@ namespace GitReleaseManager.Core
                     {
                         if (!File.Exists(asset))
                         {
-                            var message = string.Format(CultureInfo.InvariantCulture, "Requested asset to be uploaded doesn't exist: {0}", asset);
+                            var message = string.Format(CultureInfo.CurrentCulture, "The requested asset to be uploaded doesn't exist: {0}", asset);
                             throw new FileNotFoundException(message);
                         }
 
@@ -155,7 +155,7 @@ namespace GitReleaseManager.Core
 
                             if (_vcsProvider is GitLabProvider)
                             {
-                                _logger.Error("Deleting of assets is not currently supported when targetting GitLab.");
+                                _logger.Error("Deleting assets is not currently supported when targeting GitLab.");
                             }
                             else
                             {
@@ -186,7 +186,7 @@ namespace GitReleaseManager.Core
                         if (!release.Body.Contains(_configuration.Create.ShaSectionHeading))
                         {
                             _logger.Debug("Creating SHA section header");
-                            stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, "### {0}", _configuration.Create.ShaSectionHeading));
+                            stringBuilder.AppendFormat(CultureInfo.InvariantCulture, "### {0}", _configuration.Create.ShaSectionHeading).AppendLine();
                         }
 
                         foreach (var asset in assets)
@@ -405,7 +405,7 @@ namespace GitReleaseManager.Core
                 }
                 catch (ForbiddenException)
                 {
-                    _logger.Error("Unable to add comment to issue #{IssueNumber}. Insufficient permissions.", issue.PublicNumber);
+                    _logger.Error("Unable to add a comment to issue #{IssueNumber}. Insufficient permissions.", issue.PublicNumber);
                     break;
                 }
             }

--- a/src/GitReleaseManager.Core/VcsService.cs
+++ b/src/GitReleaseManager.Core/VcsService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -141,7 +142,7 @@ namespace GitReleaseManager.Core
                     {
                         if (!File.Exists(asset))
                         {
-                            var message = string.Format("Requested asset to be uploaded doesn't exist: {0}", asset);
+                            var message = string.Format(CultureInfo.InvariantCulture, "Requested asset to be uploaded doesn't exist: {0}", asset);
                             throw new FileNotFoundException(message);
                         }
 
@@ -185,7 +186,7 @@ namespace GitReleaseManager.Core
                         if (!release.Body.Contains(_configuration.Create.ShaSectionHeading))
                         {
                             _logger.Debug("Creating SHA section header");
-                            stringBuilder.AppendLine(string.Format("### {0}", _configuration.Create.ShaSectionHeading));
+                            stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, "### {0}", _configuration.Create.ShaSectionHeading));
                         }
 
                         foreach (var asset in assets)
@@ -199,7 +200,7 @@ namespace GitReleaseManager.Core
 
                             _logger.Debug("Creating SHA checksum for {Name}.", file.Name);
 
-                            stringBuilder.AppendFormat(_configuration.Create.ShaSectionLineFormat, file.Name, ComputeSha256Hash(asset));
+                            stringBuilder.AppendFormat(CultureInfo.InvariantCulture, _configuration.Create.ShaSectionLineFormat, file.Name, ComputeSha256Hash(asset));
                             stringBuilder.AppendLine();
                         }
 

--- a/src/GitReleaseManager.Core/VcsService.cs
+++ b/src/GitReleaseManager.Core/VcsService.cs
@@ -395,7 +395,7 @@ namespace GitReleaseManager.Core
                 }
                 catch (ForbiddenException)
                 {
-                    _logger.Error("Unable to add comment to issue #{IssueNumber}. Insufficient permissions.", issue.Number);
+                    _logger.Error("Unable to add comment to issue #{IssueNumber}. Insufficient permissions.", issue.PublicNumber);
                     break;
                 }
             }
@@ -403,7 +403,7 @@ namespace GitReleaseManager.Core
 
         private async Task<bool> CommentsIncludeStringAsync(string owner, string repository, Issue issue, string comment)
         {
-            _logger.Verbose("Finding issue comment created by GitReleaseManager for issue #{IssueNumber}", issue.Number);
+            _logger.Verbose("Finding issue comment created by GitReleaseManager for issue #{IssueNumber}", issue.PublicNumber);
             var issueComments = await _vcsProvider.GetIssueCommentsAsync(owner, repository, issue).ConfigureAwait(false);
 
             return issueComments.Any(c => c.Body.Contains(comment));

--- a/src/GitReleaseManager.Core/VcsService.cs
+++ b/src/GitReleaseManager.Core/VcsService.cs
@@ -151,7 +151,15 @@ namespace GitReleaseManager.Core
                         if (existingAsset != null)
                         {
                             _logger.Warning("Requested asset to be uploaded already exists on draft release, replacing with new file: {AssetPath}", asset);
-                            await _vcsProvider.DeleteAssetAsync(owner, repository, existingAsset.Id).ConfigureAwait(false);
+
+                            if (_vcsProvider is GitLabProvider)
+                            {
+                                _logger.Error("Deleting of assets is not currently supported when targetting GitLab.");
+                            }
+                            else
+                            {
+                                await _vcsProvider.DeleteAssetAsync(owner, repository, existingAsset).ConfigureAwait(false);
+                            }
                         }
 
                         var upload = new ReleaseAssetUpload

--- a/src/GitReleaseManager.Core/VcsService.cs
+++ b/src/GitReleaseManager.Core/VcsService.cs
@@ -383,14 +383,15 @@ namespace GitReleaseManager.Core
 
                 try
                 {
+                    var issueType = _vcsProvider.GetIssueType(issue);
                     if (!await CommentsIncludeStringAsync(owner, repository, issue, detectionComment).ConfigureAwait(false))
                     {
-                        _logger.Information("Adding release comment for issue #{IssueNumber}", issue.Number);
+                        _logger.Information("Adding release comment for {IssueType} #{IssueNumber}", issueType, issue.PublicNumber);
                         await _vcsProvider.CreateIssueCommentAsync(owner, repository, issue, issueComment).ConfigureAwait(false);
                     }
                     else
                     {
-                        _logger.Information("Issue #{IssueNumber} already contains release comment, skipping...", issue.Number);
+                        _logger.Information("{IssueType} #{IssueNumber} already contains release comment, skipping...", issueType, issue.PublicNumber);
                     }
                 }
                 catch (ForbiddenException)

--- a/src/GitReleaseManager.IntegrationTests/GitHubProviderIntegrationTests.cs
+++ b/src/GitReleaseManager.IntegrationTests/GitHubProviderIntegrationTests.cs
@@ -6,7 +6,6 @@ using GitReleaseManager.Core;
 using GitReleaseManager.Core.Provider;
 using NUnit.Framework;
 using Octokit;
-using Serilog;
 using Shouldly;
 using Issue = GitReleaseManager.Core.Model.Issue;
 using Milestone = GitReleaseManager.Core.Model.Milestone;
@@ -24,7 +23,6 @@ namespace GitReleaseManager.IntegrationTests
         private GitHubProvider _gitHubProvider;
         private IGitHubClient _gitHubClient;
         private IMapper _mapper;
-        private ILogger _logger;
 
         private string _token;
         private string _releaseBaseTag;
@@ -43,7 +41,6 @@ namespace GitReleaseManager.IntegrationTests
             }
 
             _mapper = AutoMapperConfiguration.Configure();
-            _logger = new LoggerConfiguration().WriteTo.Console().CreateLogger();
             _gitHubClient = new GitHubClient(new ProductHeaderValue("GitReleaseManager")) { Credentials = new Credentials(_token) };
             _gitHubProvider = new GitHubProvider(_gitHubClient, _mapper);
         }

--- a/src/GitReleaseManager.IntegrationTests/GitHubProviderIntegrationTests.cs
+++ b/src/GitReleaseManager.IntegrationTests/GitHubProviderIntegrationTests.cs
@@ -70,7 +70,7 @@ namespace GitReleaseManager.IntegrationTests
         [Order(3)]
         public async Task Should_Get_Issues()
         {
-            var result = await _gitHubProvider.GetIssuesAsync(OWNER, REPOSITORY, _milestone.Number).ConfigureAwait(false);
+            var result = await _gitHubProvider.GetIssuesAsync(OWNER, REPOSITORY, _milestone).ConfigureAwait(false);
             result.Count().ShouldBeGreaterThan(0);
 
             _issue = result.First();
@@ -80,7 +80,7 @@ namespace GitReleaseManager.IntegrationTests
         [Order(4)]
         public async Task Should_Get_Issue_Comments()
         {
-            var result = await _gitHubProvider.GetIssueCommentsAsync(OWNER, REPOSITORY, _issue.Number).ConfigureAwait(false);
+            var result = await _gitHubProvider.GetIssueCommentsAsync(OWNER, REPOSITORY, _issue).ConfigureAwait(false);
             result.Count().ShouldBeGreaterThan(0);
         }
 

--- a/src/GitReleaseManager.IntegrationTests/GitHubProviderIntegrationTests.cs
+++ b/src/GitReleaseManager.IntegrationTests/GitHubProviderIntegrationTests.cs
@@ -63,7 +63,7 @@ namespace GitReleaseManager.IntegrationTests
             var result = await _gitHubProvider.GetMilestonesAsync(OWNER, REPOSITORY).ConfigureAwait(false);
             result.Count().ShouldBeGreaterThan(0);
 
-            _milestone = result.OrderByDescending(m => m.Number).First();
+            _milestone = result.OrderByDescending(m => m.PublicNumber).First();
         }
 
         [Test]

--- a/src/GitReleaseManager.IntegrationTests/GitLabProviderIntegrationTests.cs
+++ b/src/GitReleaseManager.IntegrationTests/GitLabProviderIntegrationTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using GitReleaseManager.Core;
+using GitReleaseManager.Core.Provider;
+using NGitLab;
+using NUnit.Framework;
+using Serilog;
+using Shouldly;
+using Issue = GitReleaseManager.Core.Model.Issue;
+using Milestone = GitReleaseManager.Core.Model.Milestone;
+
+namespace GitReleaseManager.IntegrationTests
+{
+    [TestFixture]
+    [Explicit]
+    public class GitLabProviderIntegrationTests
+    {
+        private const string OWNER = "gep13";
+        private const string REPOSITORY = "grm-test";
+        private const bool SKIP_PRERELEASES = false;
+
+        private GitLabProvider _gitLabProvider;
+        private IGitLabClient _gitLabClient;
+        private IMapper _mapper;
+        private ILogger _logger;
+
+        private string _token;
+        private string _releaseBaseTag;
+        private string _releaseHeadTag;
+        private Issue _issue;
+        private Milestone _milestone;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            _token = Environment.GetEnvironmentVariable("GITTOOLS_GITLAB_TOKEN");
+
+            if (string.IsNullOrWhiteSpace(_token))
+            {
+                Assert.Inconclusive("Unable to locate credentials for accessing GitLab API");
+            }
+
+            _mapper = AutoMapperConfiguration.Configure();
+            _logger = new LoggerConfiguration().WriteTo.Console().CreateLogger();
+            _gitLabClient = new GitLabClient("https://gitlab.com", _token);
+            _gitLabProvider = new GitLabProvider(_gitLabClient, _mapper, _logger);
+        }
+
+        [Test]
+        [Order(1)]
+        public async Task Should_Get_Milestones()
+        {
+            var result = await _gitLabProvider.GetMilestonesAsync(OWNER, REPOSITORY).ConfigureAwait(false);
+            result.Count().ShouldBeGreaterThan(0);
+
+            _milestone = result.OrderByDescending(m => m.PublicNumber).First();
+        }
+
+        [Test]
+        [Order(2)]
+        public async Task Should_Get_Issues()
+        {
+            var result = await _gitLabProvider.GetIssuesAsync(OWNER, REPOSITORY, _milestone).ConfigureAwait(false);
+            result.Count().ShouldBeGreaterThan(0);
+
+            _issue = result.First();
+        }
+
+        [Test]
+        [Order(3)]
+        public async Task Should_Get_Issue_Comments()
+        {
+            var result = await _gitLabProvider.GetIssueCommentsAsync(OWNER, REPOSITORY, _issue).ConfigureAwait(false);
+            result.Count().ShouldBeGreaterThan(0);
+        }
+
+        [Test]
+        [Order(4)]
+        public async Task Should_Get_Releases()
+        {
+            var result = await _gitLabProvider.GetReleasesAsync(OWNER, REPOSITORY, SKIP_PRERELEASES).ConfigureAwait(false);
+            result.Count().ShouldBeGreaterThan(0);
+
+            var orderedReleases = result.OrderByDescending(r => r.Id).ToList();
+
+            _releaseBaseTag = orderedReleases[1].TagName;
+            _releaseHeadTag = orderedReleases[0].TagName;
+        }
+
+        [Test]
+        [Order(5)]
+        public async Task Should_Get_Commits_Count()
+        {
+            // TODO: This is waiting on a PR being merged...
+            // https://github.com/ubisoft/NGitLab/pull/444
+            // Once it is, we might be able to implement what is necessary here.
+            // var result = await _gitLabProvider.GetCommitsCountAsync(OWNER, REPOSITORY, _releaseBaseTag, _releaseHeadTag).ConfigureAwait(false);
+            // result.ShouldBeGreaterThan(0);
+        }
+    }
+}

--- a/src/GitReleaseManager.Tests/ReleaseNotesBuilderTests.cs
+++ b/src/GitReleaseManager.Tests/ReleaseNotesBuilderTests.cs
@@ -237,6 +237,9 @@ namespace GitReleaseManager.Tests
             vcsProvider.GetMilestonesAsync(owner, repository, Arg.Any<ItemStateFilter>())
                 .Returns(Task.FromResult((IEnumerable<Milestone>)vcsService.Milestones));
 
+            vcsProvider.GetMilestoneQueryString()
+                .Returns("closed=1");
+
             var builder = new ReleaseNotesBuilder(vcsProvider, logger, fileSystem, configuration, new TemplateFactory(fileSystem, configuration, TemplateKind.Create));
             var notes = builder.BuildReleaseNotesAsync(owner, repository, milestone.Title, ReleaseTemplates.DEFAULT_NAME).Result;
 

--- a/src/GitReleaseManager.Tests/ReleaseNotesBuilderTests.cs
+++ b/src/GitReleaseManager.Tests/ReleaseNotesBuilderTests.cs
@@ -231,7 +231,7 @@ namespace GitReleaseManager.Tests
             vcsProvider.GetCommitsUrl(owner, repository, Arg.Any<string>(), Arg.Any<string>())
                 .Returns(o => new GitHubProvider(null, null).GetCommitsUrl((string)o[0], (string)o[1], (string)o[2], (string)o[3]));
 
-            vcsProvider.GetIssuesAsync(owner, repository, milestoneNumber, ItemStateFilter.Closed)
+            vcsProvider.GetIssuesAsync(owner, repository, milestone, ItemStateFilter.Closed)
                 .Returns(Task.FromResult((IEnumerable<Issue>)vcsService.Issues));
 
             vcsProvider.GetMilestonesAsync(owner, repository, Arg.Any<ItemStateFilter>())

--- a/src/GitReleaseManager.Tests/ReleaseNotesBuilderTests.cs
+++ b/src/GitReleaseManager.Tests/ReleaseNotesBuilderTests.cs
@@ -249,7 +249,8 @@ namespace GitReleaseManager.Tests
             {
                 Title = version,
                 Description = description,
-                Number = 1,
+                PublicNumber = 1,
+                InternalNumber = 123,
                 HtmlUrl = "https://github.com/gep13/FakeRepository/issues?q=milestone%3A" + version,
                 Version = new Version(version),
             };

--- a/src/GitReleaseManager.Tests/ReleaseNotesBuilderTests.cs
+++ b/src/GitReleaseManager.Tests/ReleaseNotesBuilderTests.cs
@@ -263,7 +263,7 @@ namespace GitReleaseManager.Tests
         {
             return new Issue
             {
-                Number = number,
+                PublicNumber = number,
                 Labels = labels.Select(l => new Label { Name = l }).ToList(),
                 HtmlUrl = "http://example.com/" + number,
                 Title = "Issue " + number,

--- a/src/GitReleaseManager.Tool/GitReleaseManager.Tool.csproj
+++ b/src/GitReleaseManager.Tool/GitReleaseManager.Tool.csproj
@@ -38,6 +38,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="NGitLab" Version="6.39.0" />
         <PackageReference Include="Octokit" Version="7.1.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
         <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" PrivateAssets="All" />


### PR DESCRIPTION
## Description

This PR adds support to allow creation, and maintenance of, releases on GitLab.  This has been made possible using the NGItLab library.  There are some items that have been left unimplemented, see the commit messages for more details.

## Related Issue

Fixes #146 

## Motivation and Context

I work on some projects that use GitLab for private work, and I want the ability to create release notes in the same way as done on public projects on GitHub.

## How Has This Been Tested?

1. Create both a public and private repository on GitLab
2. Get token to allow maintenance of these projects
3. Create a milestone and some issues using standard GRM labels
4. Run the `create` command to create release from the milestone - this will create an "upcoming release"
5. Run the `discard` command to delete the release
6. Run the `create` command again
7. Run the `publish` command to update the release to actually being releases
8. Run the `close` command to close the milestone
9. Run the `open` command to open the milestone
10. Run the `export` command to grab a markdown file version of the release that was created

The above are some sample things to do to verify things are working as expected, but various other tests have also been completed.  Let me know if you run into any problems with anything.

## Screenshots (if appropriate):

N#A

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
