### PR TITLE
Fix the problem preventing running under .NET 7.0

### DIFF
--- a/nuspec/chocolatey/GitReleaseManager.Portable.nuspec
+++ b/nuspec/chocolatey/GitReleaseManager.Portable.nuspec
@@ -19,10 +19,10 @@
         <tags>github release notes create export</tags>
     </metadata>
     <files>
-        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net48\*.exe" target="tools" />
-        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net48\*.dll" target="tools" exclude="**\Serilog.Sinks.Debug.dll" />
-        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net48\*.pdb" target="tools" />
-        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net48\*.exe.config" target="tools" />
+        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net6.0\*.exe" target="tools" />
+        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net6.0\*.dll" target="tools" exclude="**\Serilog.Sinks.Debug.dll" />
+        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net6.0\*.pdb" target="tools" />
+        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net6.0\*.exe.config" target="tools" />
         <file src="chocolateyInstall.ps1" target="tools"/>
         <file src="chocolateyUninstall.ps1" target="tools"/>
         <file src="VERIFICATION.TXT" />

--- a/nuspec/nuget/GitReleaseManager.nuspec
+++ b/nuspec/nuget/GitReleaseManager.nuspec
@@ -20,11 +20,11 @@
         <tags>github release notes create export</tags>
     </metadata>
     <files>
-        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net48\*.exe" target="tools" />
-        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net48\*.exe.config" target="tools" />
-        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net48\*.xml" target="tools" />
-        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net48\*.dll" target="tools" exclude="**\Serilog.Sinks.Debug.dll" />
-        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net48\*.pdb" target="tools" />
+        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net6.0\*.exe" target="tools" />
+        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net6.0\*.exe.config" target="tools" />
+        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net6.0\*.xml" target="tools" />
+        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net6.0\*.dll" target="tools" exclude="**\Serilog.Sinks.Debug.dll" />
+        <file src="..\..\BuildArtifacts\temp\_PublishedApplications\GitReleaseManager.Cli\net6.0\*.pdb" target="tools" />
         <file src="..\..\icons\package_icon.png" target="" />
     </files>
 </package>

--- a/src/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
+++ b/src/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
@@ -3,7 +3,7 @@
         <LangVersion>8.0</LangVersion>
         <OutputType>Exe</OutputType>
         <AssemblyName>GitReleaseManager</AssemblyName>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0</TargetFrameworks>
         <Title>GitReleaseManager.Cli</Title>
         <Description>Create release notes in markdown given a milestone</Description>
         <IsPackable>false</IsPackable>

--- a/src/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
+++ b/src/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
@@ -3,7 +3,7 @@
         <LangVersion>8.0</LangVersion>
         <OutputType>Exe</OutputType>
         <AssemblyName>GitReleaseManager</AssemblyName>
-        <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Title>GitReleaseManager.Cli</Title>
         <Description>Create release notes in markdown given a milestone</Description>
         <IsPackable>false</IsPackable>

--- a/src/GitReleaseManager.Core.Tests/GitReleaseManager.Core.Tests.csproj
+++ b/src/GitReleaseManager.Core.Tests/GitReleaseManager.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <LangVersion>8.0</LangVersion>
-        <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Title>GitReleaseManager.Core.Tests</Title>
         <Description>Test Project for GitReleaseManager.Core</Description>
         <NoWarn>$(NoWarn);CA1707;Serilog004;</NoWarn>

--- a/src/GitReleaseManager.Core/GitReleaseManager.Core.csproj
+++ b/src/GitReleaseManager.Core/GitReleaseManager.Core.csproj
@@ -4,7 +4,7 @@
     <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v15.0\TextTemplating\Microsoft.TextTemplating.targets" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v15.0\TextTemplating\Microsoft.TextTemplating.targets')" />
     <PropertyGroup>
         <LangVersion>8.0</LangVersion>
-        <TargetFrameworks>netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Title>GitReleaseManager.Core</Title>
         <Description>Create release notes in markdown given a milestone</Description>
         <IsPackable>false</IsPackable>

--- a/src/GitReleaseManager.Core/GitReleaseManager.Core.csproj
+++ b/src/GitReleaseManager.Core/GitReleaseManager.Core.csproj
@@ -4,7 +4,7 @@
     <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v15.0\TextTemplating\Microsoft.TextTemplating.targets" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v15.0\TextTemplating\Microsoft.TextTemplating.targets')" />
     <PropertyGroup>
         <LangVersion>8.0</LangVersion>
-        <TargetFrameworks>netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1</TargetFrameworks>
         <Title>GitReleaseManager.Core</Title>
         <Description>Create release notes in markdown given a milestone</Description>
         <IsPackable>false</IsPackable>
@@ -27,7 +27,7 @@
         <PackageReference Include="Scriban" Version="5.7.0" />
         <PackageReference Include="seriloganalyzer" Version="0.15.0" />
         <PackageReference Include="YamlDotNet" Version="13.7.0" />
-        <PackageReference Include="AutoMapper" Version="10.1.1" />
+        <PackageReference Include="AutoMapper" Version="12.0.1" />
     </ItemGroup>
     <ItemGroup>
         <Compile Update="Templates\ReleaseTemplates.g.cs">

--- a/src/GitReleaseManager.IntegrationTests/GitReleaseManager.IntegrationTests.csproj
+++ b/src/GitReleaseManager.IntegrationTests/GitReleaseManager.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <LangVersion>8.0</LangVersion>
-        <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Title>GitReleaseManager.IntegrationTests</Title>
         <Description>Integration Test Project for GitReleaseManager</Description>
         <NoWarn>$(NoWarn);CA1707;Serilog004;</NoWarn>

--- a/src/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
+++ b/src/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <LangVersion>8.0</LangVersion>
-        <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Title>GitReleaseManager.Tests</Title>
         <Description>Test Project for GitReleaseManager</Description>
         <NoWarn>$(NoWarn);CA1707;Serilog004;</NoWarn>


### PR DESCRIPTION
Upgrade Automapper to its latest release in order resolve the problem under .NET 7.0. However, recent version of AutoMapper have dropped support for .NET 4.8 which means that GitReleaseManager also must drop .NET 4.8

Resolves #530  