### PR TITLE
(#574) Exclude all issues with label

### DIFF
--- a/src/GitReleaseManager.Tests/ReleaseNotesBuilderTests.CorrectlyExcludeIssuesWhenBothIncludeAndExcludeLabelIsSet.approved.txt
+++ b/src/GitReleaseManager.Tests/ReleaseNotesBuilderTests.CorrectlyExcludeIssuesWhenBothIncludeAndExcludeLabelIsSet.approved.txt
@@ -1,0 +1,5 @@
+﻿As part of this release we had [10 commits](https://github.com/TestUser/FakeRepository/commits/1.2.3) which resulted in [2 issues](https://github.com/gep13/FakeRepository/issues?q=milestone%3A1.2.3?closed=1) being closed.
+
+__Feature__
+
+- [__#3__](http://example.com/3) Issue 3

--- a/src/GitReleaseManager.Tests/ReleaseNotesBuilderTests.cs
+++ b/src/GitReleaseManager.Tests/ReleaseNotesBuilderTests.cs
@@ -184,6 +184,13 @@ namespace GitReleaseManager.Tests
             Assert.True(true); // Just to make sonarlint happy
         }
 
+        [Test]
+        public void CorrectlyExcludeIssuesWhenBothIncludeAndExcludeLabelIsSet()
+        {
+            AcceptTest(10, CreateIssue(5, "Improvement", "Build"), CreateIssue(3, "Feature"));
+            Assert.True(true);
+        }
+
         private static void AcceptTest(int commits, params Issue[] issues)
         {
             AcceptTest(commits, null, null, issues);


### PR DESCRIPTION
## Description

This updates the handling on how we are excluding labels when generating
release notes.
This allows issues to be assigned with a normal label, but still be
excluded if a different label is listed in the exclusion list.


## Related Issue

fixes #574

## Motivation and Context

Previously you would need to add and remove labels between drafting a
release notes.

## How Has This Been Tested?

This has been tested by running through scenarios locally using my [FakeTestRepository](https://github.com/AdmiringWorm/FakeTestRepository)

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
