### PR TITLE
(#439) Add option to disable warning to stderr

### DIFF
--- a/src/GitReleaseManager.Cli/Logging/LogConfiguration.cs
+++ b/src/GitReleaseManager.Cli/Logging/LogConfiguration.cs
@@ -43,7 +43,7 @@ namespace GitReleaseManager.Cli.Logging
                 .Filter.ByExcluding((logEvent) => !options.Verbose && logEvent.Level == LogEventLevel.Verbose)
                 .WriteTo.Console(
                     outputTemplate: consoleTemplate,
-                    standardErrorFromLevel: LogEventLevel.Warning,
+                    standardErrorFromLevel: options.IsCISystem ? LogEventLevel.Error : LogEventLevel.Warning,
                     theme: consoleTheme));
         }
 

--- a/src/GitReleaseManager.Core/Options/BaseSubOptions.cs
+++ b/src/GitReleaseManager.Core/Options/BaseSubOptions.cs
@@ -1,9 +1,21 @@
+using System;
 using CommandLine;
 
 namespace GitReleaseManager.Core.Options
 {
     public abstract class BaseSubOptions
     {
+        protected BaseSubOptions()
+        {
+            var ciEnvironmentVariable = Environment.GetEnvironmentVariable("CI");
+
+            bool isCiSystem;
+            if (!string.IsNullOrEmpty(ciEnvironmentVariable) && bool.TryParse(ciEnvironmentVariable, out isCiSystem))
+            {
+                IsCISystem = isCiSystem;
+            }
+        }
+
         [Option("debug", HelpText = "Enable debugging console output")]
         public bool Debug { get; set; }
 
@@ -18,5 +30,8 @@ namespace GitReleaseManager.Core.Options
 
         [Option("verbose", HelpText = "Enable verbose console output")]
         public bool Verbose { get; set; }
+
+        [Option("ci", HelpText = "Configure GitReleaseManager to be compatible with CI systems")]
+        public bool IsCISystem { get; set; }
     }
 }


### PR DESCRIPTION
## Description

This updates the handling of how we output log messages to the console
to instead of blindly outputting warning messages to stderr all the
time, it will instead check if an environment variable called `CI` is
available and set to true, or the user themself have specified the
`--ci` argument.

When CI system is detected, any warnings will instead be outputted to
the normal stdout along with normal informational messages.

## Related Issue

#fixes #439

## Motivation and Context

Certain CI systems out there will abort the build every time something is written to stderr. This causes problems on these systems when GitReleaseManager is ran.

## How Has This Been Tested?

1. On a repository, create a milestone with a valid version and one that does not contain any versions.
2. Run `grm create 2>files.txt` with the appropriate arguments for the valid version, and ensure no warnings is displayed in the console.
3. Open files.txt and ensure the warnings are located in the file (A warning about the invalid version should be in the file).
4. Delete files.txt, and run `grm create --ci 2>files.txt` with the appropriate arguments for the valid version, and ensure the warnings is now displayed in the console.
5. Open files.txt and ensure the warnings of the invalid version is not located in the file.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
