### PR TITLE
(#476) Add validation of input file path handler

### DIFF
--- a/src/GitReleaseManager.Core.Tests/Commands/CreateCommandTests.cs
+++ b/src/GitReleaseManager.Core.Tests/Commands/CreateCommandTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GitReleaseManager.Core.Commands;
@@ -105,6 +106,29 @@ namespace GitReleaseManager.Core.Tests.Commands
             _logger.Received(1).Information(Arg.Any<string>());
             _logger.Received(1).Information(Arg.Any<string>(), _release.HtmlUrl);
             _logger.Received(1).Verbose(Arg.Any<string>(), _release.Body);
+        }
+
+        [Test]
+        public async Task Throws_Exception_When_Both_Milestone_And_Input_File_Specified()
+        {
+            var options = new CreateSubOptions
+            {
+                RepositoryName = "repository",
+                RepositoryOwner = "owner",
+                InputFilePath = "file.path",
+                TargetCommitish = "target commitish",
+                AssetPaths = new List<string>(),
+                Prerelease = false,
+                Milestone = "0.5.0",
+            };
+
+            Func<Task> action = async () => await _command.ExecuteAsync(options).ConfigureAwait(false);
+
+            var ex = await action.ShouldThrowAsync<InvalidOperationException>().ConfigureAwait(false);
+            ex.Message.ShouldBe("Both a milestone and an input file path have been specified. Only one of these arguments may be used at the same time when creating a release!");
+
+            _vcsService.ReceivedCalls().ShouldBeEmpty();
+            _logger.ReceivedCalls().ShouldHaveSingleItem();
         }
     }
 }

--- a/src/GitReleaseManager.Core/Commands/CreateCommand.cs
+++ b/src/GitReleaseManager.Core/Commands/CreateCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using GitReleaseManager.Core.Model;
 using GitReleaseManager.Core.Options;
@@ -29,6 +30,11 @@ namespace GitReleaseManager.Core.Commands
             }
             else if (!string.IsNullOrEmpty(options.Milestone))
             {
+                if (!string.IsNullOrWhiteSpace(options.InputFilePath))
+                {
+                    throw new InvalidOperationException("Both a milestone and an input file path have been specified. Only one of these arguments may be used at the same time when creating a release!");
+                }
+
                 _logger.Verbose("Milestone {Milestone} was specified", options.Milestone);
                 var releaseName = options.Name;
 

--- a/src/GitReleaseManager.Core/Options/CreateSubOptions.cs
+++ b/src/GitReleaseManager.Core/Options/CreateSubOptions.cs
@@ -12,13 +12,13 @@ namespace GitReleaseManager.Core.Options
         [Option('c', "targetcommitish", HelpText = "The commit to tag. Can be a branch or SHA. Defaults to repository's default branch.", Required = false)]
         public string TargetCommitish { get; set; }
 
-        [Option('m', "milestone", HelpText = "The milestone to use.", Required = false)]
+        [Option('m', "milestone", HelpText = "The milestone to use. (Can't be used together with a release notes file path).", Required = false)]
         public string Milestone { get; set; }
 
         [Option('n', "name", HelpText = "The name of the release (Typically this is the generated SemVer Version Number).", Required = false)]
         public string Name { get; set; }
 
-        [Option('i', "inputFilePath", HelpText = "The path to the file to be used as the content of the release notes.", Required = false)]
+        [Option('i', "inputFilePath", HelpText = "The path to the file to be used as the content of the release notes. (Can't be used together with a milestone)", Required = false)]
         public string InputFilePath { get; set; }
 
         [Option('t', "template", HelpText = "The name of the template file to use. Can also be a relative or absolute path (relative paths are resolved from yaml template-dir configuration). Defaults to 'default'")]


### PR DESCRIPTION
## Description

This updates how arguments are parsed when attempting to create a new
release. This disallows explicitly the use of a milestone, and an input
file path in the same call.

## Related Issue

fixes #476

## Motivation and Context

This is done as there was confusion on why specifying a input file path
was not using the release notes specified. This should make it clearer
to the caller what the issue is.

## How Has This Been Tested?

1. Run `grm create --milestone 0.5.0 -i some-relase-notes.txt` with additional valid arguments.
2. Ensure an exception is thrown explaining that these two arguments can not be used together.

## Screenshots (if appropriate):

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
