### PR TITLE
(#578) Bump Octokit to 10.0.0 to fix oversized ints

### DIFF
--- a/src/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
+++ b/src/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
@@ -23,7 +23,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Octokit" Version="9.0.0" />
+        <PackageReference Include="Octokit" Version="10.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
         <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" PrivateAssets="All" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/src/GitReleaseManager.Core.Tests/GitReleaseManager.Core.Tests.csproj
+++ b/src/GitReleaseManager.Core.Tests/GitReleaseManager.Core.Tests.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="NUnit" Version="3.14.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-        <PackageReference Include="Octokit" Version="9.0.0" />
+        <PackageReference Include="Octokit" Version="10.0.0" />
         <PackageReference Include="Shouldly" Version="4.2.1" />
     </ItemGroup>
 </Project>

--- a/src/GitReleaseManager.Core/GitReleaseManager.Core.csproj
+++ b/src/GitReleaseManager.Core/GitReleaseManager.Core.csproj
@@ -24,7 +24,7 @@
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="NGitLab" Version="6.39.0" />
-        <PackageReference Include="Octokit" Version="9.0.0" />
+        <PackageReference Include="Octokit" Version="10.0.0" />
         <PackageReference Include="Scriban" Version="5.9.0" />
         <PackageReference Include="seriloganalyzer" Version="0.15.0" />
         <PackageReference Include="YamlDotNet" Version="13.7.1" />

--- a/src/GitReleaseManager.Core/Model/Issue.cs
+++ b/src/GitReleaseManager.Core/Model/Issue.cs
@@ -6,7 +6,7 @@ namespace GitReleaseManager.Core.Model
     {
         public string Title { get; set; }
 
-        public int InternalNumber { get; set; }
+        public long InternalNumber { get; set; }
 
         public int PublicNumber { get; set; }
 

--- a/src/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
+++ b/src/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
@@ -26,6 +26,6 @@
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="NUnit" Version="3.14.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-        <PackageReference Include="Octokit" Version="9.0.0" />
+        <PackageReference Include="Octokit" Version="10.0.0" />
     </ItemGroup>
 </Project>

--- a/src/GitReleaseManager.Tool/GitReleaseManager.Tool.csproj
+++ b/src/GitReleaseManager.Tool/GitReleaseManager.Tool.csproj
@@ -39,7 +39,7 @@
         <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="NGitLab" Version="6.39.0" />
-        <PackageReference Include="Octokit" Version="9.0.0" />
+        <PackageReference Include="Octokit" Version="10.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
         <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" PrivateAssets="All" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bumped Octokit to 10.0.0 to solve https://github.com/GitTools/GitReleaseManager/issues/578

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
https://github.com/GitTools/GitReleaseManager/issues/578

## Motivation and Context
https://github.com/GitTools/GitReleaseManager/issues/578 prevents issue data from being fetched from GitHub due to issue/PR Id values that were previously `int` now being `long`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not sure testing this is really possible or appropriate. GitReleaseManager doesn't need the issue Id but the deserialization of the Issue data fails without the fix.

I did grab the CI-created NuGet package to test within our own environment to make sure it fixes the bug for us. _That is not yet complete._

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
