### PR TITLE
(#568) Set the 'Due date' when closing a milestone if configured to do so

### DIFF
--- a/src/GitReleaseManager.Core/Configuration/CloseConfig.cs
+++ b/src/GitReleaseManager.Core/Configuration/CloseConfig.cs
@@ -22,5 +22,12 @@ namespace GitReleaseManager.Core.Configuration
         [Sample(":tada: This issue has been resolved in version {milestone} :tada:\n\nThe release is available on:\n\n- [NuGet package(@{milestone})](https://nuget.org/packages/{repository}/{milestone})\n- [GitHub release](https://github.com/{owner}/{repository}/releases/tag/{milestone})\n\nYour **[GitReleaseManager](https://github.com/GitTools/GitReleaseManager)** bot :package::rocket:")]
         [YamlMember(Alias = "issue-comment", ScalarStyle = YamlDotNet.Core.ScalarStyle.Literal)]
         public string IssueCommentFormat { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the due date should be set when closing the milestone.
+        /// </summary>
+        [Description("Whether to set the due date when closing the milestone.")]
+        [YamlMember(Alias = "set-due-date")]
+        public bool SetDueDate { get; set; }
     }
 }

--- a/src/GitReleaseManager.Core/Configuration/Config.cs
+++ b/src/GitReleaseManager.Core/Configuration/Config.cs
@@ -42,6 +42,7 @@ Your **[GitReleaseManager](https://github.com/GitTools/GitReleaseManager)** bot 
             {
                 IssueComments = false,
                 IssueCommentFormat = ISSUE_COMMENT_FORMAT,
+                SetDueDate = false, // by default, do not set the due date to match previous behavior
             };
 
             DefaultBranch = "master";

--- a/src/GitReleaseManager.Core/Model/Milestone.cs
+++ b/src/GitReleaseManager.Core/Model/Milestone.cs
@@ -17,5 +17,7 @@ namespace GitReleaseManager.Core.Model
         public string Url { get; set; }
 
         public Version Version { get; set; }
+
+        public DateTimeOffset? DueOn { get; set; }
     }
 }

--- a/src/GitReleaseManager.Core/Provider/GitHubProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/GitHubProvider.cs
@@ -227,7 +227,7 @@ namespace GitReleaseManager.Core.Provider
         {
             return GitHubProvider.ExecuteAsync(async () =>
             {
-                var update = new MilestoneUpdate { State = (Octokit.ItemState)itemState };
+                var update = new MilestoneUpdate { State = (Octokit.ItemState)itemState, DueOn = milestone.DueOn };
                 await _gitHubClient.Issue.Milestone.Update(owner, repository, milestone.PublicNumber, update).ConfigureAwait(false);
             });
         }

--- a/src/GitReleaseManager.Core/Provider/GitLabProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/GitLabProvider.cs
@@ -267,6 +267,11 @@ namespace GitReleaseManager.Core.Provider
                 }
                 else if (itemState == ItemState.Closed)
                 {
+                    if (milestone.DueOn.HasValue)
+                    {
+                        mileStoneClient.Update(milestone.InternalNumber, new MilestoneUpdate { DueDate = milestone.DueOn.Value.ToString("o", CultureInfo.InvariantCulture) });
+                    }
+
                     mileStoneClient.Close(milestone.InternalNumber);
                 }
 

--- a/src/GitReleaseManager.Core/VcsService.cs
+++ b/src/GitReleaseManager.Core/VcsService.cs
@@ -254,6 +254,9 @@ namespace GitReleaseManager.Core
                 _logger.Verbose("Finding open milestone with title '{Title}' on '{Owner}/{Repository}'", milestoneTitle, owner, repository);
                 var milestone = await _vcsProvider.GetMilestoneAsync(owner, repository, milestoneTitle, ItemStateFilter.Open).ConfigureAwait(false);
 
+                // Set the due date only if configured to do so
+                milestone.DueOn = _configuration.Close.SetDueDate ? DateTimeOffset.UtcNow : (DateTimeOffset?)null;
+
                 _logger.Verbose("Closing milestone '{Title}' on '{Owner}/{Repository}'", milestoneTitle, owner, repository);
                 await _vcsProvider.SetMilestoneStateAsync(owner, repository, milestone, ItemState.Closed).ConfigureAwait(false);
 


### PR DESCRIPTION
Allow developers to set a Boolean setting indicating whether they want the due date to be set when a milestone is closed.

By default, this config setting is set to "false" to preserve the current behavior.