### PR TITLE
(#495) Allow milestones without issues

### DIFF
--- a/docs/input/docs/configuration/default-configuration.md
+++ b/docs/input/docs/configuration/default-configuration.md
@@ -21,6 +21,7 @@ create:
     sha-section-line-format: "- `{1}\t{0}`"
     allow-update-to-published: false
     include-contributors: false
+    allow-milestone-without-issues: false
 export:
     include-created-date-in-title: false
     created-date-string-format: ''
@@ -142,6 +143,11 @@ control the look and feel of the generated release notes.
       in the release notes. A contributor is defined as someone who opened an issue
       or submitted a PR. **NOTE:** This configuration option was added in version
       0.19.0 of GitReleaseManager.
+- **allow-milestone-without-issues**
+  - A boolean value which indicates whether an empty release will be created, when
+      no issues are found to be associated with a milestone. The contents of the
+      empty release can be controlled via the associated Scriban template.
+      **NOTE:** This configuration option was added in version 0.20.0 of GitReleaseManager.
 
 See the [example create configuration section](create-configuration) to see an
 example of how a footer can be configured.

--- a/src/GitReleaseManager.Core.Tests/VcsServiceTests.cs
+++ b/src/GitReleaseManager.Core.Tests/VcsServiceTests.cs
@@ -8,7 +8,6 @@ using GitReleaseManager.Core.Configuration;
 using GitReleaseManager.Core.Model;
 using GitReleaseManager.Core.Provider;
 using GitReleaseManager.Core.ReleaseNotes;
-using GitReleaseManager.Core.Templates;
 using NSubstitute;
 using NUnit.Framework;
 using Serilog;
@@ -303,7 +302,7 @@ namespace GitReleaseManager.Core.Tests
         {
             var release = new Release();
 
-            _releaseNotesBuilder.BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, ReleaseTemplates.DEFAULT_NAME)
+            _releaseNotesBuilder.BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, null)
                 .Returns(Task.FromResult(RELEASE_NOTES));
 
             _vcsProvider.GetReleaseAsync(OWNER, REPOSITORY, MILESTONE_TITLE)
@@ -315,7 +314,7 @@ namespace GitReleaseManager.Core.Tests
             var result = await _vcsService.CreateReleaseFromMilestoneAsync(OWNER, REPOSITORY, MILESTONE_TITLE, MILESTONE_TITLE, null, null, false, null).ConfigureAwait(false);
             result.ShouldBeSameAs(release);
 
-            await _releaseNotesBuilder.Received(1).BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, ReleaseTemplates.DEFAULT_NAME).ConfigureAwait(false);
+            await _releaseNotesBuilder.Received(1).BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, null).ConfigureAwait(false);
             await _vcsProvider.Received(1).GetReleaseAsync(OWNER, REPOSITORY, MILESTONE_TITLE).ConfigureAwait(false);
             await _vcsProvider.Received(1).CreateReleaseAsync(OWNER, REPOSITORY, Arg.Is<Release>(o =>
                 o.Body == RELEASE_NOTES &&
@@ -333,7 +332,7 @@ namespace GitReleaseManager.Core.Tests
 
             var assetsCount = _assets.Count;
 
-            _releaseNotesBuilder.BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, ReleaseTemplates.DEFAULT_NAME)
+            _releaseNotesBuilder.BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, null)
                 .Returns(Task.FromResult(RELEASE_NOTES));
 
             _vcsProvider.GetReleaseAsync(OWNER, REPOSITORY, MILESTONE_TITLE)
@@ -353,7 +352,7 @@ namespace GitReleaseManager.Core.Tests
                     null).ConfigureAwait(false);
             result.ShouldBeSameAs(release);
 
-            await _releaseNotesBuilder.Received(1).BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, ReleaseTemplates.DEFAULT_NAME).ConfigureAwait(false);
+            await _releaseNotesBuilder.Received(1).BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, null).ConfigureAwait(false);
             await _vcsProvider.Received(1).GetReleaseAsync(OWNER, REPOSITORY, MILESTONE_TITLE).ConfigureAwait(false);
             await _vcsProvider.Received(1).CreateReleaseAsync(OWNER, REPOSITORY, Arg.Is<Release>(o =>
                 o.Body == RELEASE_NOTES &&
@@ -430,7 +429,7 @@ namespace GitReleaseManager.Core.Tests
 
             _configuration.Create.AllowUpdateToPublishedRelease = updatePublishedRelease;
 
-            _releaseNotesBuilder.BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, ReleaseTemplates.DEFAULT_NAME)
+            _releaseNotesBuilder.BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, null)
                 .Returns(Task.FromResult(RELEASE_NOTES));
 
             _vcsProvider.GetReleaseAsync(OWNER, REPOSITORY, MILESTONE_TITLE)
@@ -442,7 +441,7 @@ namespace GitReleaseManager.Core.Tests
             var result = await _vcsService.CreateReleaseFromMilestoneAsync(OWNER, REPOSITORY, MILESTONE_TITLE, MILESTONE_TITLE, null, null, false, null).ConfigureAwait(false);
             result.ShouldBeSameAs(release);
 
-            await _releaseNotesBuilder.Received(1).BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, ReleaseTemplates.DEFAULT_NAME).ConfigureAwait(false);
+            await _releaseNotesBuilder.Received(1).BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, null).ConfigureAwait(false);
             await _vcsProvider.Received(1).GetReleaseAsync(OWNER, REPOSITORY, MILESTONE_TITLE).ConfigureAwait(false);
             await _vcsProvider.Received(1).UpdateReleaseAsync(OWNER, REPOSITORY, release).ConfigureAwait(false);
 
@@ -458,7 +457,7 @@ namespace GitReleaseManager.Core.Tests
 
             _configuration.Create.AllowUpdateToPublishedRelease = false;
 
-            _releaseNotesBuilder.BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, ReleaseTemplates.DEFAULT_NAME)
+            _releaseNotesBuilder.BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, null)
                 .Returns(Task.FromResult(RELEASE_NOTES));
 
             _vcsProvider.GetReleaseAsync(OWNER, REPOSITORY, MILESTONE_TITLE)
@@ -467,7 +466,7 @@ namespace GitReleaseManager.Core.Tests
             var ex = await Should.ThrowAsync<InvalidOperationException>(() => _vcsService.CreateReleaseFromMilestoneAsync(OWNER, REPOSITORY, MILESTONE_TITLE, MILESTONE_TITLE, null, null, false, null)).ConfigureAwait(false);
             ex.Message.ShouldBe($"Release with tag '{MILESTONE_TITLE}' not in draft state, so not updating");
 
-            await _releaseNotesBuilder.Received(1).BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, ReleaseTemplates.DEFAULT_NAME).ConfigureAwait(false);
+            await _releaseNotesBuilder.Received(1).BuildReleaseNotesAsync(OWNER, REPOSITORY, MILESTONE_TITLE, null).ConfigureAwait(false);
             await _vcsProvider.Received(1).GetReleaseAsync(OWNER, REPOSITORY, MILESTONE_TITLE).ConfigureAwait(false);
         }
 

--- a/src/GitReleaseManager.Core/Configuration/Config.cs
+++ b/src/GitReleaseManager.Core/Configuration/Config.cs
@@ -27,6 +27,7 @@ Your **[GitReleaseManager](https://github.com/GitTools/GitReleaseManager)** bot 
                 ShaSectionHeading = "SHA256 Hashes of the release artifacts",
                 ShaSectionLineFormat = "- `{1}\t{0}`",
                 AllowUpdateToPublishedRelease = false,
+                AllowMilestonesWithoutIssues = false,
                 IncludeContributors = false,
             };
 

--- a/src/GitReleaseManager.Core/Configuration/CreateConfig.cs
+++ b/src/GitReleaseManager.Core/Configuration/CreateConfig.cs
@@ -35,6 +35,9 @@ namespace GitReleaseManager.Core.Configuration
         [YamlMember(Alias = "allow-update-to-published")]
         public bool AllowUpdateToPublishedRelease { get; set; }
 
+        [YamlMember(Alias = "allow-milestone-without-issues")]
+        public bool AllowMilestonesWithoutIssues { get; set; }
+
         [YamlMember(Alias = "include-contributors")]
         public bool IncludeContributors { get; set; }
     }

--- a/src/GitReleaseManager.Core/ReleaseNotes/ReleaseNotesBuilder.cs
+++ b/src/GitReleaseManager.Core/ReleaseNotes/ReleaseNotesBuilder.cs
@@ -58,7 +58,7 @@ namespace GitReleaseManager.Core.ReleaseNotes
 
             var numberOfCommits = await _vcsProvider.GetCommitsCountAsync(_user, _repository, @base, head).ConfigureAwait(false);
 
-            if (issues.Count == 0)
+            if (issues.Count == 0 && !_configuration.Create.AllowMilestonesWithoutIssues)
             {
                 var logMessage = string.Format(CultureInfo.CurrentCulture, "No closed issues have been found for milestone {0}, or all assigned issues are meant to be excluded from release notes, aborting release creation.", _milestoneTitle);
                 throw new InvalidOperationException(logMessage);

--- a/src/GitReleaseManager.Core/ReleaseNotes/ReleaseNotesBuilder.cs
+++ b/src/GitReleaseManager.Core/ReleaseNotes/ReleaseNotesBuilder.cs
@@ -35,7 +35,7 @@ namespace GitReleaseManager.Core.ReleaseNotes
             _templateFactory = templateFactory;
         }
 
-        public async Task<string> BuildReleaseNotesAsync(string user, string repository, string milestoneTitle, string template)
+        public async Task<string> BuildReleaseNotesAsync(string user, string repository, string milestoneTitle, string customTemplate)
         {
             _user = user;
             _repository = repository;
@@ -62,6 +62,25 @@ namespace GitReleaseManager.Core.ReleaseNotes
             {
                 var logMessage = string.Format(CultureInfo.CurrentCulture, "No closed issues have been found for milestone {0}, or all assigned issues are meant to be excluded from release notes, aborting release creation.", _milestoneTitle);
                 throw new InvalidOperationException(logMessage);
+            }
+
+            // By default we use the custom template, if it was provided.
+            // Otherwise, we determine which template we should use.
+            var template = customTemplate;
+            if (string.IsNullOrWhiteSpace(template))
+            {
+                if (issues.Count == 0)
+                {
+                    template = ReleaseTemplates.NO_ISSUES_NAME;
+                }
+                else if (_configuration.Create.IncludeContributors)
+                {
+                    template = ReleaseTemplates.CONTRIBUTORS_NAME;
+                }
+                else
+                {
+                    template = ReleaseTemplates.DEFAULT_NAME;
+                }
             }
 
             var commitsLink = _vcsProvider.GetCommitsUrl(_user, _repository, _targetMilestone?.Title, previousMilestone?.Title);

--- a/src/GitReleaseManager.Core/Templates/no_issues/create/footer.sbn
+++ b/src/GitReleaseManager.Core/Templates/no_issues/create/footer.sbn
@@ -1,0 +1,10 @@
+{{ if config.create.include_footer }}
+
+### {{ config.create.footer_heading }}
+
+{{  if config.create.milestone_replace_text
+        replace_milestone_title config.create.footer_content config.create.milestone_replace_text milestone.target.title
+    else
+        config.create.footer_content
+    end
+end }}

--- a/src/GitReleaseManager.Core/Templates/no_issues/index.sbn
+++ b/src/GitReleaseManager.Core/Templates/no_issues/index.sbn
@@ -1,0 +1,10 @@
+{{-
+    include 'release-info'
+    if milestone.target.description
+        include 'milestone'
+    end
+    include 'issues' | string.rstrip
+    if template_kind == "CREATE"
+        include 'create/footer'
+    end
+~}}

--- a/src/GitReleaseManager.Core/Templates/no_issues/issues.sbn
+++ b/src/GitReleaseManager.Core/Templates/no_issues/issues.sbn
@@ -1,0 +1,2 @@
+
+This release had no issues associated with it.

--- a/src/GitReleaseManager.Core/Templates/no_issues/milestone.sbn
+++ b/src/GitReleaseManager.Core/Templates/no_issues/milestone.sbn
@@ -1,0 +1,2 @@
+
+{{ milestone.target.description }}

--- a/src/GitReleaseManager.Core/Templates/no_issues/release-info.sbn
+++ b/src/GitReleaseManager.Core/Templates/no_issues/release-info.sbn
@@ -1,0 +1,4 @@
+{{
+    if commits.count > 0
+}}As part of this release we had [{{ commits.count }} {{ commits.count | string.pluralize "commit" "commits" }}]({{ commits.html_url }}).
+{{  end -}}

--- a/src/GitReleaseManager.Core/VcsService.cs
+++ b/src/GitReleaseManager.Core/VcsService.cs
@@ -13,7 +13,6 @@ using GitReleaseManager.Core.Extensions;
 using GitReleaseManager.Core.Model;
 using GitReleaseManager.Core.Provider;
 using GitReleaseManager.Core.ReleaseNotes;
-using GitReleaseManager.Core.Templates;
 using Serilog;
 
 namespace GitReleaseManager.Core
@@ -46,16 +45,7 @@ namespace GitReleaseManager.Core
 
         public async Task<Release> CreateReleaseFromMilestoneAsync(string owner, string repository, string milestone, string releaseName, string targetCommitish, IList<string> assets, bool prerelease, string templateFilePath)
         {
-            var templatePath = _configuration.Create.IncludeContributors
-                ? ReleaseTemplates.CONTRIBUTORS_NAME
-                : ReleaseTemplates.DEFAULT_NAME;
-
-            if (!string.IsNullOrWhiteSpace(templateFilePath))
-            {
-                templatePath = templateFilePath;
-            }
-
-            var releaseNotes = await _releaseNotesBuilder.BuildReleaseNotesAsync(owner, repository, milestone, templatePath).ConfigureAwait(false);
+            var releaseNotes = await _releaseNotesBuilder.BuildReleaseNotesAsync(owner, repository, milestone, templateFilePath).ConfigureAwait(false);
             var release = await CreateReleaseAsync(owner, repository, releaseName, milestone, releaseNotes, prerelease, targetCommitish, assets).ConfigureAwait(false);
 
             return release;
@@ -67,7 +57,7 @@ namespace GitReleaseManager.Core
 
             _logger.Verbose("Reading release notes from: '{FilePath}'", inputFilePath);
 
-            var releaseNotes = File.ReadAllText(inputFilePath);
+            var releaseNotes = await File.ReadAllTextAsync(inputFilePath).ConfigureAwait(false);
             var release = await CreateReleaseAsync(owner, repository, name, name, releaseNotes, prerelease, targetCommitish, assets).ConfigureAwait(false);
 
             return release;


### PR DESCRIPTION
Allow developers to specify whether they want to allow a release to be created even when the milestone is not associated with any issues.

Regarding #495 