### PR TITLE
(WIP) Add output of draft release and split out VCS Provider

### DIFF
--- a/src/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
+++ b/src/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <LangVersion>8.0</LangVersion>
         <OutputType>Exe</OutputType>

--- a/src/GitReleaseManager.Core/GitReleaseManager.Core.csproj
+++ b/src/GitReleaseManager.Core/GitReleaseManager.Core.csproj
@@ -4,6 +4,8 @@
     <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v15.0\TextTemplating\Microsoft.TextTemplating.targets" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v15.0\TextTemplating\Microsoft.TextTemplating.targets')" />
     <PropertyGroup>
         <LangVersion>8.0</LangVersion>
+        <!-- Uncomment the below property when langversion is updated to 9.0 or higher (optimally 11.0). -->
+        <!--<DefineConstants>$(DefineConstants);USE_GENERATED_REGEX</DefineConstants>-->
         <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Title>GitReleaseManager.Core</Title>
         <Description>Create release notes in markdown given a milestone</Description>

--- a/src/GitReleaseManager.Core/Helpers/FileSystem.cs
+++ b/src/GitReleaseManager.Core/Helpers/FileSystem.cs
@@ -19,6 +19,21 @@ namespace GitReleaseManager.Core.Helpers
             File.Copy(@source, destination, overwrite);
         }
 
+        public void CreateDirectory(string path)
+        {
+            // It is safe to call CreateDirectory, if the directory
+            // already exists these are no-op.
+
+            if (string.IsNullOrEmpty(path))
+            {
+                Directory.CreateDirectory(Environment.CurrentDirectory);
+            }
+            else
+            {
+                Directory.CreateDirectory(path);
+            }
+        }
+
         public void Move(string @source, string destination)
         {
             File.Move(@source, destination);
@@ -59,9 +74,19 @@ namespace GitReleaseManager.Core.Helpers
             return Directory.GetFiles(directory, searchPattern, searchOption);
         }
 
+        public Stream OpenRead(string path)
+        {
+            return File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        }
+
         public Stream OpenWrite(string path)
         {
-            return File.OpenWrite(path);
+            return OpenWrite(path, overwrite: false);
+        }
+
+        public Stream OpenWrite(string path, bool overwrite)
+        {
+            return File.Open(path, overwrite ? FileMode.Create : FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
         }
     }
 }

--- a/src/GitReleaseManager.Core/Helpers/IFileSystem.cs
+++ b/src/GitReleaseManager.Core/Helpers/IFileSystem.cs
@@ -7,6 +7,8 @@ namespace GitReleaseManager.Core.Helpers
     {
         void Copy(string source, string destination, bool overwrite);
 
+        void CreateDirectory(string path);
+
         void Move(string source, string destination);
 
         bool Exists(string file);
@@ -21,6 +23,9 @@ namespace GitReleaseManager.Core.Helpers
 
         IEnumerable<string> DirectoryGetFiles(string directory, string searchPattern, SearchOption searchOption);
 
+        Stream OpenRead(string path);
+
         Stream OpenWrite(string path);
+        Stream OpenWrite(string path, bool overwrite);
     }
 }

--- a/src/GitReleaseManager.Core/Options/CreateSubOptions.cs
+++ b/src/GitReleaseManager.Core/Options/CreateSubOptions.cs
@@ -29,5 +29,8 @@ namespace GitReleaseManager.Core.Options
 
         [Option("allowEmpty", Required = false, HelpText = "Allow the creation of an empty set of release notes. In this mode, milestone and input file path will be ignored.")]
         public bool AllowEmpty { get; set; }
+
+        [Option("output", Required = false, HelpText = "The path to a local file location where the release notes will be created, instead of creating in remotely on the specified provider.")]
+        public string OutputPath { get; set; }
     }
 }

--- a/src/GitReleaseManager.Core/Provider/GitHubProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/GitHubProvider.cs
@@ -35,6 +35,8 @@ namespace GitReleaseManager.Core.Provider
             _mapper = mapper;
         }
 
+        public string Name => "GitHub";
+
         public Task DeleteAssetAsync(string owner, string repository, ReleaseAsset asset)
         {
             return ExecuteAsync(async () =>

--- a/src/GitReleaseManager.Core/Provider/GitLabProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/GitLabProvider.cs
@@ -43,6 +43,8 @@ namespace GitReleaseManager.Core.Provider
             _logger = logger;
         }
 
+        public string Name => "GitLab";
+
         public Task DeleteAssetAsync(string owner, string repository, ReleaseAsset asset)
         {
             // TODO: This is a discussion here:

--- a/src/GitReleaseManager.Core/Provider/IAssetsProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/IAssetsProvider.cs
@@ -1,0 +1,14 @@
+namespace GitReleaseManager.Core.Provider
+{
+    using System.Threading.Tasks;
+    using GitReleaseManager.Core.Model;
+
+    public interface IAssetsProvider
+    {
+        bool SupportsAssets { get; }
+
+        Task DeleteAssetAsync(string owner, string repository, ReleaseAsset asset);
+
+        Task UploadAssetAsync(Release release, ReleaseAssetUpload releaseAssetUpload);
+    }
+}

--- a/src/GitReleaseManager.Core/Provider/ICommitsProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/ICommitsProvider.cs
@@ -1,0 +1,13 @@
+namespace GitReleaseManager.Core.Provider
+{
+    using System.Threading.Tasks;
+
+    public interface ICommitsProvider
+    {
+        bool SupportsCommits { get; }
+
+        Task<int> GetCommitsCountAsync(string owner, string repository, string baseCommit, string headCommit);
+
+        string GetCommitsUrl(string owner, string repository, string head, string baseCommit = null);
+    }
+}

--- a/src/GitReleaseManager.Core/Provider/IIssuesProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/IIssuesProvider.cs
@@ -1,0 +1,20 @@
+namespace GitReleaseManager.Core.Provider
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using GitReleaseManager.Core.Model;
+
+    public interface IIssuesProvider
+    {
+        bool SupportIssues { get; }
+        bool SupportIssueComments { get; }
+
+        Task CreateIssueCommentAsync(string owner, string repository, Issue issue, string comment);
+
+        Task<IEnumerable<IssueComment>> GetIssueCommentsAsync(string owner, string repository, Issue issue);
+
+        Task<IEnumerable<Issue>> GetIssuesAsync(string owner, string repository, Milestone milstone, ItemStateFilter itemStateFilter = ItemStateFilter.All);
+
+        string GetIssueType(Issue issue);
+    }
+}

--- a/src/GitReleaseManager.Core/Provider/ILabelsProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/ILabelsProvider.cs
@@ -1,0 +1,17 @@
+namespace GitReleaseManager.Core.Provider
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using GitReleaseManager.Core.Model;
+
+    public interface ILabelsProvider
+    {
+        bool SupportsLabels { get; }
+
+        Task CreateLabelAsync(string owner, string repository, Label label);
+
+        Task DeleteLabelAsync(string owner, string repository, Label label);
+
+        Task<IEnumerable<Label>> GetLabelsAsync(string owner, string repository);
+    }
+}

--- a/src/GitReleaseManager.Core/Provider/IMilestonesProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/IMilestonesProvider.cs
@@ -1,0 +1,19 @@
+namespace GitReleaseManager.Core.Provider
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using GitReleaseManager.Core.Model;
+
+    public interface IMilestonesProvider
+    {
+        bool SupportMilestones { get; }
+
+        Task<Milestone> GetMilestoneAsync(string owner, string repository, string milestoneTitle, ItemStateFilter itemStateFilter = ItemStateFilter.All);
+
+        Task<IEnumerable<Milestone>> GetMilestonesAsync(string owner, string repository, ItemStateFilter itemStateFilter = ItemStateFilter.All);
+
+        Task SetMilestoneStateAsync(string owner, string repository, Milestone milestone, ItemState itemState);
+
+        string GetMilestoneQueryString();
+    }
+}

--- a/src/GitReleaseManager.Core/Provider/IRateLimitProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/IRateLimitProvider.cs
@@ -1,0 +1,9 @@
+namespace GitReleaseManager.Core.Provider
+{
+    using GitReleaseManager.Core.Model;
+
+    public interface IRateLimitProvider
+    {
+        RateLimit GetRateLimit();
+    }
+}

--- a/src/GitReleaseManager.Core/Provider/IReleasesProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/IReleasesProvider.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GitReleaseManager.Core.Model;
+
+namespace GitReleaseManager.Core.Provider
+{
+    public interface IReleasesProvider
+    {
+        bool SupportReleases { get; }
+
+        Task<Release> CreateReleaseAsync(string owner, string repository, Release release);
+
+        Task DeleteReleaseAsync(string owner, string repository, Release release);
+
+        Task<Release> GetReleaseAsync(string owner, string repository, string tagName);
+
+        Task<IEnumerable<Release>> GetReleasesAsync(string owner, string repository, bool skipPrereleases);
+
+        Task PublishReleaseAsync(string owner, string repository, string tagName, Release release);
+
+        Task UpdateReleaseAsync(string owner, string repository, Release release);
+    }
+}

--- a/src/GitReleaseManager.Core/Provider/IVcsProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/IVcsProvider.cs
@@ -4,50 +4,7 @@ using GitReleaseManager.Core.Model;
 
 namespace GitReleaseManager.Core.Provider
 {
-    public interface IVcsProvider
+    public interface IVcsProvider : IAssetsProvider, ICommitsProvider, IIssuesProvider, IMilestonesProvider, IRateLimitProvider, IReleasesProvider
     {
-        Task DeleteAssetAsync(string owner, string repository, ReleaseAsset asset);
-
-        Task UploadAssetAsync(Release release, ReleaseAssetUpload releaseAssetUpload);
-
-        Task<int> GetCommitsCountAsync(string owner, string repository, string @base, string head);
-
-        string GetCommitsUrl(string owner, string repository, string head, string @base = null);
-
-        Task CreateIssueCommentAsync(string owner, string repository, Issue issue, string comment);
-
-        Task<IEnumerable<Issue>> GetIssuesAsync(string owner, string repository, Milestone milstone, ItemStateFilter itemStateFilter = ItemStateFilter.All);
-
-        Task<IEnumerable<IssueComment>> GetIssueCommentsAsync(string owner, string repository, Issue issue);
-
-        Task CreateLabelAsync(string owner, string repository, Label label);
-
-        Task DeleteLabelAsync(string owner, string repository, Label label);
-
-        Task<IEnumerable<Label>> GetLabelsAsync(string owner, string repository);
-
-        Task<Milestone> GetMilestoneAsync(string owner, string repository, string milestoneTitle, ItemStateFilter itemStateFilter = ItemStateFilter.All);
-
-        Task<IEnumerable<Milestone>> GetMilestonesAsync(string owner, string repository, ItemStateFilter itemStateFilter = ItemStateFilter.All);
-
-        Task SetMilestoneStateAsync(string owner, string repository, Milestone milestone, ItemState itemState);
-
-        Task<Release> CreateReleaseAsync(string owner, string repository, Release release);
-
-        Task DeleteReleaseAsync(string owner, string repository, Release release);
-
-        Task<Release> GetReleaseAsync(string owner, string repository, string tagName);
-
-        Task<IEnumerable<Release>> GetReleasesAsync(string owner, string repository, bool skipPrereleases);
-
-        Task PublishReleaseAsync(string owner, string repository, string tagName, Release release);
-
-        Task UpdateReleaseAsync(string owner, string repository, Release release);
-
-        RateLimit GetRateLimit();
-
-        string GetMilestoneQueryString();
-
-        string GetIssueType(Issue issue);
     }
 }

--- a/src/GitReleaseManager.Core/Provider/LocalProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/LocalProvider.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using GitReleaseManager.Core.Helpers;
+using GitReleaseManager.Core.Model;
+
+namespace GitReleaseManager.Core.Provider
+{
+    public partial class LocalProvider : IReleasesProvider
+    {
+        private const string NAME_AND_TAG_REGEX = @"^#+\s*(?<NAME>[^\(\r\n]+)(?:\s*\((?<TAG_NAME>[^\)\r\n]+))?";
+        private readonly IFileSystem _fileSystem;
+        private readonly string _outputPath;
+
+        public LocalProvider(IFileSystem fileSystem, string outputPath)
+        {
+            _fileSystem = fileSystem;
+            _outputPath = outputPath;
+        }
+
+        public bool SupportReleases => true;
+
+        public async Task<Release> CreateReleaseAsync(string owner, string repository, Release release)
+        {
+            ArgumentNullException.ThrowIfNull(release);
+
+            string directory = Path.GetDirectoryName(_outputPath) ?? Environment.CurrentDirectory;
+            _fileSystem.CreateDirectory(directory);
+
+#pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task
+            await using (var stream = _fileSystem.OpenWrite(_outputPath, overwrite: true))
+            await using (StreamWriter writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true)))
+#pragma warning restore CA2007 // Consider calling ConfigureAwait on the awaited task
+            {
+                await writer.WriteAsync("# ").ConfigureAwait(false);
+                await writer.WriteAsync(release.Name ?? release.TagName).ConfigureAwait(false);
+
+                if (release.Name != null && release.Name != release.TagName)
+                {
+                    await writer.WriteAsync(" (").ConfigureAwait(false);
+                    await writer.WriteAsync(release.TagName).ConfigureAwait(false);
+                    await writer.WriteLineAsync(")").ConfigureAwait(false);
+                }
+                else
+                {
+                    await writer.WriteLineAsync().ConfigureAwait(false);
+                }
+
+                await writer.WriteLineAsync().ConfigureAwait(false);
+
+                await writer.WriteLineAsync(release.Body).ConfigureAwait(false);
+
+                await writer.FlushAsync().ConfigureAwait(false);
+            }
+
+            release.CreatedAt = DateTime.UtcNow;
+            release.HtmlUrl = _outputPath;
+
+            return release;
+        }
+
+        public Task DeleteReleaseAsync(string owner, string repository, Release release)
+        {
+            _fileSystem.Delete(_outputPath);
+
+            return Task.CompletedTask;
+        }
+
+        public async Task<Release> GetReleaseAsync(string owner, string repository, string tagName)
+        {
+            Release release = new Release();
+            await using (var stream = _fileSystem.OpenRead(_outputPath))
+            using (StreamReader reader = new StreamReader(stream, Encoding.UTF8))
+            {
+                var line = await reader.ReadLineAsync();
+                var titleMatch = NameAndTagNameRegex().Match(line);
+
+                if (titleMatch.Success)
+                {
+                    release.Name = titleMatch.Groups["NAME"].Value;
+
+                    if (titleMatch.Groups["TAG_NAME"].Success)
+                    {
+                        release.TagName = titleMatch.Groups["TAG_NAME"].Value;
+                    }
+                }
+
+                line = await reader.ReadLineAsync();
+
+                while (string.IsNullOrEmpty(line))
+                {
+                    line = await reader.ReadLineAsync();
+                }
+
+                var body = new StringBuilder(line).AppendLine();
+                var block = await reader.ReadToEndAsync();
+
+                if (block.Length > 0)
+                {
+                    body.Append(block);
+                }
+
+                if (release.Name.Length == 0 && body.Length == 0)
+                {
+                    return null;
+                }
+                else
+                {
+                    release.Body = body.ToString();
+                    release.Draft = true;
+                    release.HtmlUrl = _outputPath;
+                    release.Prerelease = Regex.IsMatch(@"^\d\.+-[a-z]", release.Name, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                }
+            }
+
+            return release;
+        }
+
+        public Task<IEnumerable<Release>> GetReleasesAsync(string owner, string repository, bool skipPrereleases)
+        {
+            return Task.FromResult<IEnumerable<Release>>(null);
+        }
+
+        public Task PublishReleaseAsync(string owner, string repository, string tagName, Release release)
+        {
+            // No-op
+            return Task.CompletedTask;
+        }
+
+        public async Task UpdateReleaseAsync(string owner, string repository, Release release)
+        {
+            await DeleteReleaseAsync(owner, repository, release).ConfigureAwait(false);
+            await CreateReleaseAsync(owner, repository, release).ConfigureAwait(false);
+        }
+
+#if NET7_0_OR_GREATER && USE_GENERATED_REGEX
+        [GeneratedRegex(NAME_AND_TAG_REGEX, RegexOptions.IgnoreCase)]
+        private static partial Regex NameAndTagNameRegex();
+#else
+        private static Regex NameAndTagNameRegex()
+        {
+            return new Regex(NAME_AND_TAG_REGEX, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        }
+#endif
+    }
+}

--- a/src/GitReleaseManager.Core/Provider/NullReleasesProvider.cs
+++ b/src/GitReleaseManager.Core/Provider/NullReleasesProvider.cs
@@ -1,0 +1,167 @@
+namespace GitReleaseManager.Core.Provider
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using GitReleaseManager.Core.Model;
+    using Serilog;
+
+    public class NullReleasesProvider : IVcsProvider
+    {
+        private readonly string _vcsProvider;
+        private readonly ILogger _logger;
+
+        public NullReleasesProvider(string vcsProvider, ILogger logger)
+        {
+            _vcsProvider = vcsProvider;
+            _logger = logger;
+        }
+
+        public bool SupportsAssets => false;
+
+        public bool SupportsCommits => false;
+
+        public bool SupportIssues => false;
+
+        public bool SupportIssueComments => false;
+
+        public bool SupportMilestones => false;
+
+        public bool SupportReleases => false;
+
+        public Task CreateIssueCommentAsync(string owner, string repository, Issue issue, string comment)
+        {
+            _logger.Warning("The provider '{Provider}' do not support creating issue comments!", _vcsProvider);
+            return Task.CompletedTask;
+        }
+
+        public Task CreateLabelAsync(string owner, string repository, Label label)
+        {
+            _logger.Warning("The provider '{Provider}' do not support creating labels!", _vcsProvider);
+            return Task.CompletedTask;
+        }
+
+        public Task<Release> CreateReleaseAsync(string owner, string repository, Release release)
+        {
+            _logger.Warning("The provider '{Provider}' do not support creating releases!", _vcsProvider);
+            return Task.FromResult<Release>(null);
+        }
+
+        public Task DeleteAssetAsync(string owner, string repository, ReleaseAsset asset)
+        {
+            _logger.Warning("The provider '{Provider}' do not support deleting assets!", _vcsProvider);
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteLabelAsync(string owner, string repository, Label label)
+        {
+            _logger.Warning("The provider '{Provider}' do not support deleting labels!", _vcsProvider);
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteReleaseAsync(string owner, string repository, Release release)
+        {
+            _logger.Warning("The provider '{Provider}' do not support releases labels!", _vcsProvider);
+            return Task.CompletedTask;
+        }
+
+        public Task<int> GetCommitsCountAsync(string owner, string repository, string @base, string head)
+        {
+            _logger.Warning("The provider '{Provider}' do not support acquiring commits!", _vcsProvider);
+            return Task.FromResult(0);
+        }
+
+        public string GetCommitsUrl(string owner, string repository, string head, string @base = null)
+        {
+            _logger.Warning("The provider '{Provider}' do not support acquiring commits!", _vcsProvider);
+            return null;
+        }
+
+        public Task<IEnumerable<IssueComment>> GetIssueCommentsAsync(string owner, string repository, Issue issue)
+        {
+            _logger.Warning("The provider '{Provider}' do not support acquiring issue comments!", _vcsProvider);
+            return Task.FromResult(Enumerable.Empty<IssueComment>());
+        }
+
+        public Task<IEnumerable<Issue>> GetIssuesAsync(string owner, string repository, Milestone milstone, ItemStateFilter itemStateFilter = ItemStateFilter.All)
+        {
+            _logger.Warning("The provider '{Provider}' do not support acquiring issues!", _vcsProvider);
+            return Task.FromResult(Enumerable.Empty<Issue>());
+        }
+
+        public string GetIssueType(Issue issue)
+        {
+            _logger.Warning("The provider '{Provider}' do not support acquiring issues!", _vcsProvider);
+            return null;
+        }
+
+        public Task<IEnumerable<Label>> GetLabelsAsync(string owner, string repository)
+        {
+            _logger.Warning("The provider '{Provider}' do not support acquiring labels!", _vcsProvider);
+            return Task.FromResult(Enumerable.Empty<Label>());
+        }
+
+        public Task<Milestone> GetMilestoneAsync(string owner, string repository, string milestoneTitle, ItemStateFilter itemStateFilter = ItemStateFilter.All)
+        {
+            _logger.Warning("The provider '{Provider}' do not support acquiring milestones!", _vcsProvider);
+            return Task.FromResult<Milestone>(null);
+        }
+
+        public string GetMilestoneQueryString()
+        {
+            _logger.Warning("The provider '{Provider}' do not support acquiring milestones!", _vcsProvider);
+            return null;
+        }
+
+        public Task<IEnumerable<Milestone>> GetMilestonesAsync(string owner, string repository, ItemStateFilter itemStateFilter = ItemStateFilter.All)
+        {
+            _logger.Warning("The provider '{Provider}' do not support acquiring milestones!", _vcsProvider);
+            return Task.FromResult(Enumerable.Empty<Milestone>());
+        }
+
+        public RateLimit GetRateLimit()
+        {
+            return new RateLimit
+            {
+                Limit = int.MaxValue,
+                Remaining = int.MaxValue,
+            };
+        }
+
+        public Task<Release> GetReleaseAsync(string owner, string repository, string tagName)
+        {
+            _logger.Warning("The provider '{Provider}' do not support acquiring releases!", _vcsProvider);
+            return Task.FromResult<Release>(null);
+        }
+
+        public Task<IEnumerable<Release>> GetReleasesAsync(string owner, string repository, bool skipPrereleases)
+        {
+            _logger.Warning("The provider '{Provider}' do not support acquiring releases!", _vcsProvider);
+            return Task.FromResult(Enumerable.Empty<Release>());
+        }
+
+        public Task PublishReleaseAsync(string owner, string repository, string tagName, Release release)
+        {
+            _logger.Warning("The provider '{Provider}' do not support publishing releases!", _vcsProvider);
+            return Task.CompletedTask;
+        }
+
+        public Task SetMilestoneStateAsync(string owner, string repository, Milestone milestone, ItemState itemState)
+        {
+            _logger.Warning("The provider '{Provider} do not support updating milestones!", _vcsProvider);
+            return Task.CompletedTask;
+        }
+
+        public Task UpdateReleaseAsync(string owner, string repository, Release release)
+        {
+            _logger.Warning("The provider '{Provider}' do not support updating releases!", _vcsProvider);
+            return Task.CompletedTask;
+        }
+
+        public Task UploadAssetAsync(Release release, ReleaseAssetUpload releaseAssetUpload)
+        {
+            _logger.Warning("The provider '{Provider}' do not support uploading assets!", _vcsProvider);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR when it is ready aims to split out the entire VCS provider to more simple interfaces that can be implemented to provider different supported scenarios for a VCS provider.

Additionally, it also aims to add support to output a drafted release notes to disk instead of creating it remotely on GitHub/GitLab

## Related Issue

- Fixes #629
- Fixes #630

## Motivation and Context

Why not.

## How Has This Been Tested?

Not properly tested yet.....

## Screenshots (if appropriate):

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
