### PR TITLE
add github actions configuration for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
 - package-ecosystem: nuget
   directory: "/src"
   schedule:


### PR DESCRIPTION
Include `github actions` in the dependabot configuration