### PR TITLE
Groups for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,27 @@ version: 2
 updates:
 - package-ecosystem: github-actions
   directory: "/"
+  labels:
+    - "Build"
   schedule:
     interval: daily
 - package-ecosystem: nuget
   directory: "/src"
+  labels:
+    - "Build"
+  groups:
+    analyzers:
+      patterns:
+      - "*Analyzers"
+    serilog:
+      patterns:
+        - "Serilog.*"
+    tests:
+      patterns:
+      - "NUnit.*"
+      - "Microsoft.NET.Test.Sdk"
+      - "NSubstitute"
+      - "coverlet.msbuild"
   schedule:
     interval: daily
   open-pull-requests-limit: 10


### PR DESCRIPTION
It is possible to group together several packages in one single PR. By default the PRs will have the `Build` label, which might be changed to something else after the PR is created