### PR TITLE
(maint) Move common project properties to Directory.Build.props

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,22 @@
 <Project>
     <PropertyGroup>
+        <LangVersion>8.0</LangVersion>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+
+        <Authors>GitTools Contributors</Authors>
+        <PackageProjectUrl>https://github.com/GitTools/GitReleaseManager</PackageProjectUrl>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <PackageTags>github release notes create export</PackageTags>
+        <Copyright>Copyright (c) 2015 - Present - GitTools Contributors</Copyright>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageIcon>package_icon.png</PackageIcon>
+        <PackageReleaseNotes>https://github.com/GitTools/GitReleaseManager/releases</PackageReleaseNotes>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/GitTools/GitReleaseManager.git</RepositoryUrl>
+
         <DebugType>pdbonly</DebugType>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>CS1591</NoWarn>
+        <NoWarn>$(NoWarn);CS1591;CA1707;Serilog004</NoWarn>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
     <PropertyGroup>
         <LangVersion>8.0</LangVersion>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 
         <Authors>GitTools Contributors</Authors>
         <PackageProjectUrl>https://github.com/GitTools/GitReleaseManager</PackageProjectUrl>

--- a/src/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
+++ b/src/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <AssemblyName>GitReleaseManager</AssemblyName>
+        <TargetFrameworks>net6.0</TargetFrameworks>
         <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>true</SelfContained>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>

--- a/src/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
+++ b/src/GitReleaseManager.Cli/GitReleaseManager.Cli.csproj
@@ -1,16 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <LangVersion>8.0</LangVersion>
         <OutputType>Exe</OutputType>
         <AssemblyName>GitReleaseManager</AssemblyName>
-        <TargetFrameworks>net6.0</TargetFrameworks>
         <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>true</SelfContained>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>
         <Title>GitReleaseManager.Cli</Title>
         <Description>Create release notes in markdown given a milestone</Description>
         <IsPackable>false</IsPackable>
-        <NoWarn>$(NoWarn);CA1707;</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\GitReleaseManager.Core\GitReleaseManager.Core.csproj" />

--- a/src/GitReleaseManager.Core.Tests/GitReleaseManager.Core.Tests.csproj
+++ b/src/GitReleaseManager.Core.Tests/GitReleaseManager.Core.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Title>GitReleaseManager.Core.Tests</Title>
         <Description>Test Project for GitReleaseManager.Core</Description>
     </PropertyGroup>

--- a/src/GitReleaseManager.Core.Tests/GitReleaseManager.Core.Tests.csproj
+++ b/src/GitReleaseManager.Core.Tests/GitReleaseManager.Core.Tests.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <LangVersion>9.0</LangVersion>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Title>GitReleaseManager.Core.Tests</Title>
         <Description>Test Project for GitReleaseManager.Core</Description>
-        <NoWarn>$(NoWarn);CA1707;Serilog004;</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="..\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />

--- a/src/GitReleaseManager.Core/GitReleaseManager.Core.csproj
+++ b/src/GitReleaseManager.Core/GitReleaseManager.Core.csproj
@@ -3,6 +3,7 @@
     <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v16.0\TextTemplating\Microsoft.TextTemplating.targets" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v16.0\TextTemplating\Microsoft.TextTemplating.targets')" />
     <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v15.0\TextTemplating\Microsoft.TextTemplating.targets" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v15.0\TextTemplating\Microsoft.TextTemplating.targets')" />
     <PropertyGroup>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Title>GitReleaseManager.Core</Title>
         <Description>Create release notes in markdown given a milestone</Description>
         <IsPackable>false</IsPackable>

--- a/src/GitReleaseManager.Core/GitReleaseManager.Core.csproj
+++ b/src/GitReleaseManager.Core/GitReleaseManager.Core.csproj
@@ -3,12 +3,9 @@
     <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v16.0\TextTemplating\Microsoft.TextTemplating.targets" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v16.0\TextTemplating\Microsoft.TextTemplating.targets')" />
     <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v15.0\TextTemplating\Microsoft.TextTemplating.targets" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v15.0\TextTemplating\Microsoft.TextTemplating.targets')" />
     <PropertyGroup>
-        <LangVersion>8.0</LangVersion>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Title>GitReleaseManager.Core</Title>
         <Description>Create release notes in markdown given a milestone</Description>
         <IsPackable>false</IsPackable>
-        <NoWarn>$(NoWarn);CA1707;</NoWarn>
         <TransformOnBuild>true</TransformOnBuild>
     </PropertyGroup>
 

--- a/src/GitReleaseManager.IntegrationTests/GitReleaseManager.IntegrationTests.csproj
+++ b/src/GitReleaseManager.IntegrationTests/GitReleaseManager.IntegrationTests.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <LangVersion>8.0</LangVersion>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Title>GitReleaseManager.IntegrationTests</Title>
         <Description>Integration Test Project for GitReleaseManager</Description>
-        <NoWarn>$(NoWarn);CA1707;Serilog004;</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="..\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />

--- a/src/GitReleaseManager.IntegrationTests/GitReleaseManager.IntegrationTests.csproj
+++ b/src/GitReleaseManager.IntegrationTests/GitReleaseManager.IntegrationTests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Title>GitReleaseManager.IntegrationTests</Title>
         <Description>Integration Test Project for GitReleaseManager</Description>
     </PropertyGroup>

--- a/src/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
+++ b/src/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Title>GitReleaseManager.Tests</Title>
         <Description>Test Project for GitReleaseManager</Description>
     </PropertyGroup>

--- a/src/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
+++ b/src/GitReleaseManager.Tests/GitReleaseManager.Tests.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <LangVersion>8.0</LangVersion>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Title>GitReleaseManager.Tests</Title>
         <Description>Test Project for GitReleaseManager</Description>
-        <NoWarn>$(NoWarn);CA1707;Serilog004;</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="..\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />

--- a/src/GitReleaseManager.Tool/GitReleaseManager.Tool.csproj
+++ b/src/GitReleaseManager.Tool/GitReleaseManager.Tool.csproj
@@ -3,6 +3,7 @@
         <OutputType>Exe</OutputType>
         <AssemblyName>GitReleaseManager</AssemblyName>
         <PackAsTool>true</PackAsTool>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <ToolCommandName>dotnet-gitreleasemanager</ToolCommandName>
         <PackageId>GitReleaseManager.Tool</PackageId>
         <Title>GitReleaseManager Tool</Title>

--- a/src/GitReleaseManager.Tool/GitReleaseManager.Tool.csproj
+++ b/src/GitReleaseManager.Tool/GitReleaseManager.Tool.csproj
@@ -1,25 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <LangVersion>8.0</LangVersion>
         <OutputType>Exe</OutputType>
         <AssemblyName>GitReleaseManager</AssemblyName>
         <PackAsTool>true</PackAsTool>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <ToolCommandName>dotnet-gitreleasemanager</ToolCommandName>
         <PackageId>GitReleaseManager.Tool</PackageId>
         <Title>GitReleaseManager Tool</Title>
-        <Authors>GitTools Contributors</Authors>
-        <PackageProjectUrl>https://github.com/GitTools/GitReleaseManager</PackageProjectUrl>
-        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageTags>github release notes create export</PackageTags>
         <Description>Tool for creating and exporting releases for software applications from online Version Control Systems</Description>
-        <Copyright>Copyright (c) 2015 - Present - GitTools Contributors</Copyright>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageIcon>package_icon.png</PackageIcon>
-        <PackageReleaseNotes>https://github.com/GitTools/GitReleaseManager/releases</PackageReleaseNotes>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/GitTools/GitReleaseManager.git</RepositoryUrl>
-        <NoWarn>$(NoWarn);CA1707;</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="../GitReleaseManager.Cli/**/*.cs" Exclude="../GitReleaseManager.Cli/obj/**/*.*;../GitReleaseManager.Cli/bin/**/*.*" />


### PR DESCRIPTION
This should improve the maintenance of the common properties. When we upgrade to .net80 and .net90, that will be much simpler